### PR TITLE
Do not re-seed RNG in solve()

### DIFF
--- a/src/solve.jl
+++ b/src/solve.jl
@@ -316,14 +316,6 @@ function init(
     if !(typeof(W) <: NoiseGrid) && W.t[end] != t
       error("Starting time in the noise process is not the starting time of the simulation. The noise process should be re-initialized for repeated use")
     end
-    # Reseed
-    if typeof(W) <: NoiseProcess
-      if prob.seed != 0
-        srand(W.rng,seed)
-      else
-        srand(W.rng,seed)
-      end
-    end
   end
 
   EEst = tTypeNoUnits(1)


### PR DESCRIPTION
Suggestion: do not re-seed RNG in solve()

I don't think implicitly re-seeding RNG given explicitly by user is the best thing to do.  I think users setting RNG explicitly are likely to prefer controlling the state of RNG.  I suggest to set the seed only when `prob.noise` is `nothing`.

(BTW, the `if prob.seed != 0` block in the old code is suspicious since `if` and `else` block do the same thing.)

One benefit of this patch is that you can do more "rigorous" Monte Carlo simulations by making parallel "independent" streams of RNG using the *jump function*.  The designers of pseudo RNG recommend to use it for parallel simulations (see e.g., http://xoroshiro.di.unimi.it/).  As @ChrisRackauckas mentioned here https://github.com/JuliaDiffEq/DifferentialEquations.jl/issues/182#issuecomment-311155957, using the "simulation id" (second argument of `prob_func`) as the seed is probably OK for most use-cases.  But why not allow a better way to do it?  I think this patch is required for this.