### PR TITLE
Update implicit methods to use lazy W

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -12,3 +12,4 @@ Reexport
 RandomNumbers
 MuladdMacro
 DiffEqDiffTools 0.3.0
+DiffEqOperators 3.1.0

--- a/src/StochasticDiffEq.jl
+++ b/src/StochasticDiffEq.jl
@@ -16,6 +16,8 @@ module StochasticDiffEq
   import DiffEqBase: ODE_DEFAULT_NORM, ODE_DEFAULT_ISOUTOFDOMAIN,
          ODE_DEFAULT_PROG_MESSAGE, ODE_DEFAULT_UNSTABLE_CHECK
 
+  using DiffEqOperators: DiffEqArrayOperator
+
   import RecursiveArrayTools: chain
 
   using Logging

--- a/src/caches/implicit_split_step_caches.jl
+++ b/src/caches/implicit_split_step_caches.jl
@@ -1,4 +1,4 @@
-mutable struct ISSEMCache{uType,rateType,J,JC,UF,
+mutable struct ISSEMCache{uType,rateType,J,W,JC,UF,
                           uEltypeNoUnits,noiseRateType,F,dWType} <:
                           StochasticDiffEqMutableCache
   u::uType
@@ -12,7 +12,7 @@ mutable struct ISSEMCache{uType,rateType,J,JC,UF,
   gtmp::noiseRateType
   gtmp2::rateType
   J::J
-  W::J
+  W::W
   jac_config::JC
   linsolve::F
   uf::UF
@@ -29,8 +29,13 @@ du_cache(c::ISSEMCache)   = (c.k,c.fsalfirst)
 function alg_cache(alg::ISSEM,prob,u,ΔW,ΔZ,p,rate_prototype,noise_rate_prototype,
                    uEltypeNoUnits,uBottomEltype,tTypeNoUnits,uprev,f,t,::Type{Val{true}})
   du1 = zero(rate_prototype)
-  J = zeros(uEltypeNoUnits,length(u),length(u)) # uEltype?
-  W = zero(J)
+  if has_jac(f) && !has_invW(f) && f.jac_prototype != nothing
+    W = WOperator(f, zero(t))
+    J = nothing
+  else
+    J = zeros(uEltypeNoUnits,length(u),length(u)) # uEltype?
+    W = similar(J)
+  end
   z = zero(u)
   dz = zero(u); tmp = zero(u); gtmp = zero(noise_rate_prototype)
   fsalfirst = zero(rate_prototype)
@@ -93,7 +98,7 @@ function alg_cache(alg::ISSEM,prob,u,ΔW,ΔZ,p,rate_prototype,noise_rate_prototy
   ISSEMConstantCache(uf,ηold,κ,tol,100000)
 end
 
-mutable struct ISSEulerHeunCache{uType,rateType,J,JC,UF,uEltypeNoUnits,
+mutable struct ISSEulerHeunCache{uType,rateType,J,W,JC,UF,uEltypeNoUnits,
                                  noiseRateType,F,dWType} <:
                                  StochasticDiffEqMutableCache
   u::uType
@@ -108,7 +113,7 @@ mutable struct ISSEulerHeunCache{uType,rateType,J,JC,UF,uEltypeNoUnits,
   gtmp2::rateType
   gtmp3::noiseRateType
   J::J
-  W::J
+  W::W
   jac_config::JC
   linsolve::F
   uf::UF
@@ -125,8 +130,13 @@ du_cache(c::ISSEulerHeunCache)   = (c.k,c.fsalfirst)
 function alg_cache(alg::ISSEulerHeun,prob,u,ΔW,ΔZ,p,rate_prototype,noise_rate_prototype,
                    uEltypeNoUnits,uBottomEltype,tTypeNoUnits,uprev,f,t,::Type{Val{true}})
   du1 = zero(rate_prototype)
-  J = zeros(uEltypeNoUnits,length(u),length(u)) # uEltype?
-  W = zero(J)
+  if has_jac(f) && !has_invW(f) && f.jac_prototype != nothing
+    W = WOperator(f, zero(t))
+    J = nothing
+  else
+    J = zeros(uEltypeNoUnits,length(u),length(u)) # uEltype?
+    W = similar(J)
+  end
   z = zero(u)
   dz = zero(u); tmp = zero(u); gtmp = zero(noise_rate_prototype)
   fsalfirst = zero(rate_prototype)

--- a/src/caches/sdirk_caches.jl
+++ b/src/caches/sdirk_caches.jl
@@ -1,4 +1,4 @@
-mutable struct ImplicitEMCache{uType,rateType,J,JC,UF,uEltypeNoUnits,noiseRateType,F,dWType} <: StochasticDiffEqMutableCache
+mutable struct ImplicitEMCache{uType,rateType,J,W,JC,UF,uEltypeNoUnits,noiseRateType,F,dWType} <: StochasticDiffEqMutableCache
   u::uType
   uprev::uType
   du1::rateType
@@ -10,7 +10,7 @@ mutable struct ImplicitEMCache{uType,rateType,J,JC,UF,uEltypeNoUnits,noiseRateTy
   gtmp::noiseRateType
   gtmp2::rateType
   J::J
-  W::J
+  W::W
   jac_config::JC
   linsolve::F
   uf::UF
@@ -27,8 +27,13 @@ du_cache(c::ImplicitEMCache)   = (c.k,c.fsalfirst)
 function alg_cache(alg::ImplicitEM,prob,u,ΔW,ΔZ,p,rate_prototype,noise_rate_prototype,
                    uEltypeNoUnits,uBottomEltype,tTypeNoUnits,uprev,f,t,::Type{Val{true}})
   du1 = zero(rate_prototype)
-  J = zeros(uEltypeNoUnits,length(u),length(u)) # uEltype?
-  W = zero(J)
+  if has_jac(f) && !has_invW(f) && f.jac_prototype != nothing
+    W = WOperator(f, zero(t))
+    J = nothing
+  else
+    J = zeros(uEltypeNoUnits,length(u),length(u)) # uEltype?
+    W = similar(J)
+  end
   z = zero(u)
   dz = zero(u); tmp = zero(u); gtmp = zero(noise_rate_prototype)
   fsalfirst = zero(rate_prototype)
@@ -91,7 +96,7 @@ function alg_cache(alg::ImplicitEM,prob,u,ΔW,ΔZ,p,rate_prototype,noise_rate_pr
   ImplicitEMConstantCache(uf,ηold,κ,tol,100000)
 end
 
-mutable struct ImplicitEulerHeunCache{uType,rateType,J,JC,UF,uEltypeNoUnits,noiseRateType,F,dWType} <: StochasticDiffEqMutableCache
+mutable struct ImplicitEulerHeunCache{uType,rateType,J,W,JC,UF,uEltypeNoUnits,noiseRateType,F,dWType} <: StochasticDiffEqMutableCache
   u::uType
   uprev::uType
   du1::rateType
@@ -104,7 +109,7 @@ mutable struct ImplicitEulerHeunCache{uType,rateType,J,JC,UF,uEltypeNoUnits,nois
   gtmp2::rateType
   gtmp3::noiseRateType
   J::J
-  W::J
+  W::W
   jac_config::JC
   linsolve::F
   uf::UF
@@ -121,8 +126,13 @@ du_cache(c::ImplicitEulerHeunCache)   = (c.k,c.fsalfirst)
 function alg_cache(alg::ImplicitEulerHeun,prob,u,ΔW,ΔZ,p,rate_prototype,noise_rate_prototype,
                    uEltypeNoUnits,uBottomEltype,tTypeNoUnits,uprev,f,t,::Type{Val{true}})
   du1 = zero(rate_prototype)
-  J = zeros(uEltypeNoUnits,length(u),length(u)) # uEltype?
-  W = zero(J)
+  if has_jac(f) && !has_invW(f) && f.jac_prototype != nothing
+    W = WOperator(f, zero(t))
+    J = nothing
+  else
+    J = zeros(uEltypeNoUnits,length(u),length(u)) # uEltype?
+    W = similar(J)
+  end
   z = zero(u)
   dz = zero(u); tmp = zero(u); gtmp = zero(noise_rate_prototype)
   fsalfirst = zero(rate_prototype)
@@ -187,7 +197,7 @@ function alg_cache(alg::ImplicitEulerHeun,prob,u,ΔW,ΔZ,p,rate_prototype,noise_
   ImplicitEulerHeunConstantCache(uf,ηold,κ,tol,100000)
 end
 
-mutable struct ImplicitRKMilCache{uType,rateType,J,JC,UF,uEltypeNoUnits,noiseRateType,F} <: StochasticDiffEqMutableCache
+mutable struct ImplicitRKMilCache{uType,rateType,J,W,JC,UF,uEltypeNoUnits,noiseRateType,F} <: StochasticDiffEqMutableCache
   u::uType
   uprev::uType
   du1::rateType
@@ -200,7 +210,7 @@ mutable struct ImplicitRKMilCache{uType,rateType,J,JC,UF,uEltypeNoUnits,noiseRat
   gtmp2::noiseRateType
   gtmp3::noiseRateType
   J::J
-  W::J
+  W::W
   jac_config::JC
   linsolve::F
   uf::UF
@@ -216,8 +226,13 @@ du_cache(c::ImplicitRKMilCache)   = (c.k,c.fsalfirst)
 function alg_cache(alg::ImplicitRKMil,prob,u,ΔW,ΔZ,p,rate_prototype,noise_rate_prototype,
                    uEltypeNoUnits,uBottomEltype,tTypeNoUnits,uprev,f,t,::Type{Val{true}})
   du1 = zero(rate_prototype)
-  J = zeros(uEltypeNoUnits,length(u),length(u)) # uEltype?
-  W = zero(J)
+  if has_jac(f) && !has_invW(f) && f.jac_prototype != nothing
+    W = WOperator(f, zero(t))
+    J = nothing
+  else
+    J = zeros(uEltypeNoUnits,length(u),length(u)) # uEltype?
+    W = similar(J)
+  end
   z = zero(u)
   dz = zero(u); tmp = zero(u); gtmp = zero(noise_rate_prototype)
   fsalfirst = zero(rate_prototype)

--- a/src/derivative_utils.jl
+++ b/src/derivative_utils.jl
@@ -23,6 +23,157 @@ function calc_J!(integrator, cache::StochasticDiffEqConstantCache, is_compos)
   end
 end
 
+"""
+    WOperator(mass_matrix,gamma,J[;transform=false])
+
+A linear operator that represents the W matrix of an ODEProblem, defined as
+
+```math
+W = MM - \\gamma J
+```
+
+or, if `transform=true`:
+
+```math
+W = \\frac{1}{\\gamma}MM - J
+```
+
+where `MM` is the mass matrix (a regular `AbstractMatrix` or a `UniformScaling`),
+`γ` is a real number proportional to the time step, and `J` is the Jacobian
+operator (must be a `AbstractDiffEqLinearOperator`). A `WOperator` can also be
+constructed using a `*DEFunction` directly as
+
+    WOperator(f,gamma[;transform=false])
+
+`f` needs to have a jacobian and `jac_prototype`, but the prototype does not need
+to be a diffeq operator --- it will automatically be converted to one.
+
+`WOperator` supports lazy `*` and `mul!` operations, the latter utilizing an
+internal cache (can be specified in the constructor; default to regular `Vector`).
+It supports all of `AbstractDiffEqLinearOperator`'s interface.
+"""
+mutable struct WOperator{T,
+  MType <: Union{UniformScaling,AbstractMatrix},
+  GType <: Real,
+  JType <: DiffEqBase.AbstractDiffEqLinearOperator{T}
+  } <: DiffEqBase.AbstractDiffEqLinearOperator{T}
+  mass_matrix::MType
+  gamma::GType
+  J::JType
+  transform::Bool       # true => W = mm/gamma - J; false => W = mm - gamma*J
+  _func_cache           # cache used in `mul!`
+  _concrete_form        # non-lazy form (matrix/number) of the operator
+  WOperator(mass_matrix, gamma, J; transform=false) = new{eltype(J),typeof(mass_matrix),
+    typeof(gamma),typeof(J)}(mass_matrix,gamma,J,transform,nothing,nothing)
+end
+function WOperator(f::DiffEqBase.AbstractODEFunction, gamma; transform=false)
+  @assert DiffEqBase.has_jac(f) "f needs to have an associated jacobian"
+  if isa(f, Union{SplitFunction, DynamicalODEFunction})
+    error("WOperator does not support $(typeof(f)) yet")
+  end
+  # Convert mass matrix, if needed
+  mass_matrix = f.mass_matrix
+  if !isa(mass_matrix, Union{AbstractMatrix,UniformScaling})
+    mass_matrix = convert(AbstractMatrix, mass_matrix)
+  end
+  # Convert jacobian, if needed
+  J = deepcopy(f.jac_prototype)
+  if !isa(J, DiffEqBase.AbstractDiffEqLinearOperator)
+    J = DiffEqArrayOperator(J; update_func=f.jac)
+  end
+  return WOperator(mass_matrix, gamma, J; transform=transform)
+end
+
+set_gamma!(W::WOperator, gamma) = (W.gamma = gamma; W)
+DiffEqBase.update_coefficients!(W::WOperator,u,p,t) = (update_coefficients!(W.J,u,p,t); W)
+function Base.convert(::Type{AbstractMatrix}, W::WOperator)
+  if W._concrete_form == nothing
+    # Allocating
+    if W.transform
+      W._concrete_form = W.mass_matrix / W.gamma - convert(AbstractMatrix,W.J)
+    else
+      W._concrete_form = W.mass_matrix - W.gamma * convert(AbstractMatrix,W.J)
+    end
+  else
+    # Non-allocating
+    if W.transform
+      rmul!(copyto!(W._concrete_form, W.mass_matrix), 1/W.gamma)
+      axpy!(-1, convert(AbstractMatrix,W.J), W._concrete_form)
+    else
+      copyto!(W._concrete_form, W.mass_matrix)
+      axpy!(-W.gamma, convert(AbstractMatrix,W.J), W._concrete_form)
+    end
+  end
+  W._concrete_form
+end
+function Base.convert(::Type{Number}, W::WOperator)
+  if W.transform
+    W._concrete_form = W.mass_matrix / W.gamma - convert(Number,W.J)
+  else
+    W._concrete_form = W.mass_matrix - W.gamma * convert(Number,W.J)
+  end
+  W._concrete_form
+end
+Base.size(W::WOperator, args...) = size(W.J, args...)
+function Base.getindex(W::WOperator, i::Int)
+  if W.transform
+    W.mass_matrix[i] / W.gamma - W.J[i]
+  else
+    W.mass_matrix[i] - W.gamma * W.J[i]
+  end
+end
+function Base.getindex(W::WOperator, I::Vararg{Int,N}) where {N}
+  if W.transform
+    W.mass_matrix[I...] / W.gamma - W.J[I...]
+  else
+    W.mass_matrix[I...] - W.gamma * W.J[I...]
+  end
+end
+function Base.:*(W::WOperator, x::Union{AbstractVecOrMat,Number})
+  if W.transform
+    (W.mass_matrix*x) / W.gamma - W.J*x
+  else
+    W.mass_matrix*x - W.gamma * (W.J*x)
+  end
+end
+function Base.:\(W::WOperator, x::Union{AbstractVecOrMat,Number})
+  if size(W) == () # scalar operator
+    convert(Number,W) \ x
+  else
+    convert(AbstractMatrix,W) \ x
+  end
+end
+function LinearAlgebra.mul!(Y::AbstractVecOrMat, W::WOperator, B::AbstractVecOrMat)
+  if W._func_cache == nothing
+    # Allocate cache only if needed
+    W._func_cache = Vector{eltype(W)}(undef, size(Y, 1))
+  end
+  if W.transform
+    # Compute mass_matrix * B
+    if isa(W.mass_matrix, UniformScaling)
+      a = W.mass_matrix.λ / W.gamma
+      @. Y = a * B
+    else
+      mul!(Y, W.mass_matrix, B)
+      lmul!(1/W.gamma, Y)
+    end
+    # Compute J * B and subtract
+    mul!(W._func_cache, W.J, B)
+    Y .-= W._func_cache
+  else
+    # Compute mass_matrix * B
+    if isa(W.mass_matrix, UniformScaling)
+      @. Y = W.mass_matrix.λ * B
+    else
+      mul!(Y, W.mass_matrix, B)
+    end
+    # Compute J * B
+    mul!(W._func_cache, W.J, B)
+    # Subtract result
+    axpy!(-W.gamma, W._func_cache, Y)
+  end
+end
+
 function calc_W!(integrator, cache::StochasticDiffEqMutableCache, γdt, repeat_step)
   @inbounds begin
     @unpack t,dt,uprev,u,f,p, alg = integrator

--- a/src/derivative_utils.jl
+++ b/src/derivative_utils.jl
@@ -59,7 +59,7 @@ mutable struct WOperator{T,
   WOperator(mass_matrix, gamma, J) = new{eltype(J),typeof(mass_matrix),
     typeof(gamma),typeof(J)}(mass_matrix,gamma,J,nothing,nothing)
 end
-function WOperator(f::DiffEqBase.AbstractODEFunction, gamma)
+function WOperator(f::DiffEqBase.AbstractSDEFunction, gamma)
   @assert DiffEqBase.has_jac(f) "f needs to have an associated jacobian"
   if isa(f, Union{SplitFunction, DynamicalODEFunction})
     error("WOperator does not support $(typeof(f)) yet")

--- a/src/derivative_utils.jl
+++ b/src/derivative_utils.jl
@@ -7,7 +7,7 @@ function calc_J!(integrator, cache::StochasticDiffEqConstantCache, is_compos)
   end
   return J
 end
-function calc_J!(integrator, cache::StochasticDiffEqConstantCache, is_compos)
+function calc_J!(integrator, cache::StochasticDiffEqMutableCache, is_compos)
   @unpack t,dt,uprev,u,f,p = integrator
   J = cache.J
   if has_jac(f)
@@ -188,6 +188,6 @@ function calc_W!(integrator, cache::StochasticDiffEqConstantCache, γdt, repeat_
     end
     W = mass_matrix - γdt*J
   end
-  iscompo && (integrator.eigen_est = isarray ? opnorm(J, Inf) : J)
+  is_compos && (integrator.eigen_est = isarray ? opnorm(J, Inf) : J)
   J, W
 end

--- a/src/perform_step/implicit_split_step.jl
+++ b/src/perform_step/implicit_split_step.jl
@@ -95,7 +95,7 @@
 
   if integrator.opts.adaptive
 
-    Ed = dt*J*ftmp/2
+    Ed = dt*(J*ftmp)/2
 
     if typeof(cache) <: SplitStepEulerConstantCache
       K = @muladd uprev .+ dt.*ftmp
@@ -259,7 +259,7 @@ end
 
     if has_invW(f)
       # This means the Jacobian was never computed!
-      f(Val{:jac},J,uprev,p,t)
+      f.jac(J,uprev,p,t)
     end
 
     mul!(vec(z),J,vec(tmp))

--- a/src/perform_step/sdirk.jl
+++ b/src/perform_step/sdirk.jl
@@ -110,7 +110,7 @@
 
   if integrator.opts.adaptive
 
-    Ed = dt*J*ftmp/2
+    Ed = dt*(J*ftmp)/2
     if typeof(cache) <: Union{ImplicitEMConstantCache,ImplicitEulerHeunConstantCache}
         En = mil_correction
     else
@@ -281,7 +281,7 @@ end
 
     if has_invW(f)
       # This means the Jacobian was never computed!
-      f(Val{:jac},J,uprev,p,t)
+      f.jac(J,uprev,p,t)
     end
 
     mul!(vec(z),J,vec(tmp))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -41,6 +41,7 @@ is_APPVEYOR = ( Sys.iswindows() && haskey(ENV,"APPVEYOR") )
     @time @testset "Autostepsize Test" begin include("adaptive/sde_autostepsize_test.jl") end
     @time @testset "Additive Lorenz Attractor Test" begin include("adaptive/sde_lorenzattractor_tests.jl") end
     @time @testset "Adaptive Complex Mean Test" begin include("adaptive/sde_complex_adaptive_mean_test.jl") end
+    @time @testset "Utility Tests" begin include("utility_tests.jl") end
   end
 
   if !is_APPVEYOR && (group == "All" || group == "AlgConvergence")

--- a/test/utility_tests.jl
+++ b/test/utility_tests.jl
@@ -1,0 +1,86 @@
+using StochasticDiffEq: WOperator, set_gamma!, calc_W!
+using StochasticDiffEq, LinearAlgebra, SparseArrays, Random, Test, DiffEqOperators
+
+@testset "Derivative Utilities" begin
+  @testset "WOperator" begin
+    srand(0); y = zeros(2); b = rand(2)
+    mm = I; _J = rand(2,2)
+    W = WOperator(mm, 1.0, DiffEqArrayOperator(_J))
+    set_gamma!(W, 2.0)
+    _W = mm - 2.0 * _J
+    @test convert(AbstractMatrix,W) ≈ _W
+    @test W * b ≈ _W * b
+    mul!(y, W, b); @test y ≈ _W * b
+  end
+
+  @testset "calc_W!" begin
+    A = [-1.0 0.0; 0.0 -0.5]; σ = [0.9 0.0; 0.0 0.8]
+    # mm = [2.0 0.0; 0.0 1.0]
+    mm = I
+    u0 = [1.0, 1.0]; tmp = zeros(2)
+    tspan = (0.0,1.0); dt = 0.01
+    concrete_W = mm - dt * A
+
+    # Out-of-place
+    _f = (u,p,t) -> A*u; _g = (u,p,t) -> σ*u
+    fun = SDEFunction(_f, _g;
+                      mass_matrix=mm,
+                      jac=(u,p,t) -> A)
+    prob = SDEProblem(fun, _g, u0, tspan)
+    integrator = init(prob, ImplicitEM(); adaptive=false, dt=dt)
+    J, W = calc_W!(integrator, integrator.cache, dt, false)
+    @test convert(AbstractMatrix, W) ≈ concrete_W
+    @test W \ u0 ≈ concrete_W \ u0
+
+    # In-place
+    _f = (du,u,p,t) -> mul!(du,A,u); _g = (du,u,p,t) -> mul!(du,σ,u)
+    fun = SDEFunction(_f, _g;
+                      mass_matrix=mm,
+                      jac_prototype=DiffEqArrayOperator(A))
+    prob = SDEProblem(fun, _g, u0, tspan)
+    integrator = init(prob, ImplicitEM(); adaptive=false, dt=dt)
+    calc_W!(integrator, integrator.cache, dt, false)
+    @test convert(AbstractMatrix, integrator.cache.W) ≈ concrete_W
+    ldiv!(tmp, lu!(integrator.cache.W), u0); @test tmp ≈ concrete_W \ u0
+  end
+
+  @testset "Implicit solver with lazy W" begin
+    A = sparse([-1.0 0.0; 0.0 -0.5]); σ = sparse([0.9 0.0; 0.0 0.8])
+    # mm = sparse([2.0 0.0; 0.0 1.0])
+    mm = I
+    u0 = [1.0, 1.0]; tspan = (0.0,1.0)
+
+    _f = (u,p,t) -> t*(A*u); _f_ip = (du,u,p,t) -> lmul!(t,mul!(du,A,u))
+    _g = (u,p,t) -> σ*u; _g_ip = (du,u,p,t) -> mul!(du,σ,u)
+    prob1 = SDEProblem(SDEFunction(_f, _g; mass_matrix=mm), _g, u0, tspan)
+    prob2 = SDEProblem(SDEFunction(_f, _g; mass_matrix=mm, jac=(u,p,t) -> t*A), _g, u0, tspan)
+    prob1_ip = SDEProblem(SDEFunction(_f_ip, _g_ip; mass_matrix=mm), _g_ip, u0, tspan)
+    jac_prototype=DiffEqArrayOperator(similar(A); update_func=(J,u,p,t) -> (J .= t .* A; J))
+    prob2_ip = SDEProblem(SDEFunction(_f_ip, _g_ip; mass_matrix=mm, jac_prototype=jac_prototype), _g_ip, u0, tspan)
+
+    for Alg in [ImplicitEM, ISSEM]
+      println(Alg)
+      sol1 = solve(prob1, Alg(); adaptive=false, dt=0.01)
+      sol2 = solve(prob2, Alg(); adaptive=false, dt=0.01)
+      # @test sol1(1.0) ≈ sol2(1.0)
+      sol1_ip = solve(prob1_ip, Alg(); adaptive=false, dt=0.01)
+      sol2_ip = solve(prob2_ip, Alg(linsolve=LinSolveFactorize(lu)); adaptive=false, dt=0.01)
+      # @test sol1_ip(1.0) ≈ sol2_ip(1.0)
+    end
+
+    σ = 1.0
+    _g = (u,p,t) -> σ; _g_ip = (du,u,p,t) -> (du .= σ)
+    prob1 = SDEProblem(SDEFunction(_f, _g; mass_matrix=mm), _g, u0, tspan)
+    prob2 = SDEProblem(SDEFunction(_f, _g; mass_matrix=mm, jac=(u,p,t) -> t*A), _g, u0, tspan)
+    prob1_ip = SDEProblem(SDEFunction(_f_ip, _g_ip; mass_matrix=mm), _g_ip, u0, tspan)
+    prob2_ip = SDEProblem(SDEFunction(_f_ip, _g_ip; mass_matrix=mm, jac_prototype=jac_prototype), _g_ip, u0, tspan)
+
+    println(SKenCarp)
+    sol1 = solve(prob1, SKenCarp(); adaptive=false, dt=0.01)
+    sol2 = solve(prob2, SKenCarp(); adaptive=false, dt=0.01)
+    # @test sol1(1.0) ≈ sol2(1.0)
+    sol1_ip = solve(prob1_ip, SKenCarp(); adaptive=false, dt=0.01)
+    sol2_ip = solve(prob2_ip, SKenCarp(linsolve=LinSolveFactorize(lu)); adaptive=false, dt=0.01)
+    # @test sol1_ip(1.0) ≈ sol2_ip(1.0)
+  end
+end


### PR DESCRIPTION
Mimics what is done to OrdinaryDiffEq https://github.com/JuliaDiffEq/OrdinaryDiffEq.jl/pull/460 in StochasticDiffEq.

Notes:

1. I'm not sure if this is a mistake or deliberate choice:
   https://github.com/JuliaDiffEq/StochasticDiffEq.jl/compare/master...MSeeker1340:implicit-update?expand=1#diff-35ab888388acf2e7239e17f33e5eefe7R20
   In OrdinaryDiffEq `integrator.eigen_est` is updated regardless of which branch `calc_J!` takes, but this is not the case for StochasticDiffEq.

2. In StochasticDiffEq the return values of `calc_W!` for constant caches is `(J, W)`, whereas in OrdinaryDiffEq only `W` is returned. This seems a bit inconsistent (but on the other hand they are separate packages, so maybe it is ok?).

3. `alg_cache` in StochasticDiffEq does not have the `dt` parameter (again an inconsistency), so I've chosen to use `zero(t)` as the initial value of `dtgamma` in the construction of `WOperator`. The initial value should not matter though as it is always reset in `calc_W!`.

4. When I try to use custom mass matrices I got the error message "Algorithm must be set as symplectic or theta=1 for mass matrices". @ChrisRackauckas can you explain what this means? (Currently all mass matrices in the test scripts are `I`).

5. It occurred to me that the integration tests for OrdinaryDiffEq (in utility_tests.jl) do not work for StochasticDiffEq because the solution is indeterministic, thus cannot be compared. I'm not sure how to modify it though. Maybe do a Monte Carlo simulation?