### PR TITLE
Remove SpecialMatrices & callbacks saving fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ os:
   - linux
 #  - osx
 julia:
-  - 0.7
+  - 1.0
   - nightly
 env:
   - GROUP=Interface

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 environment:
   matrix:
-    - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.7/julia-0.7-latest-win32.exe"
-    - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.7/julia-0.7-latest-win64.exe"
+    - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/1.0/julia-1.0.0-win32.exe"
+    - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/1.0/julia-1.0.0-win64.exe"
     - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
 matrix:
   allow_failures:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,15 +1,24 @@
 environment:
   matrix:
-    - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/1.0/julia-1.0.0-win32.exe"
-    - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/1.0/julia-1.0.0-win64.exe"
-    - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
+  - julia_version: 1.0 # latest 1.0.x
+  - julia_version: 1   # latest 1.x.y
+  - julia_version: nightly
+
+platform:
+  - x86 # 32-bit
+  - x64 # 64-bit
+
+# Uncomment the following lines to allow failures on nightly julia
+# (tests will run but not make your overall status red)
 matrix:
   allow_failures:
-    - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
+  - julia_version: nightly
+
 branches:
   only:
     - master
     - /release-.*/
+
 notifications:
   - provider: Email
     on_build_success: false
@@ -17,19 +26,18 @@ notifications:
     on_build_status_changed: false
 
 install:
-  - ps: "[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12"
-# Download most recent Julia Windows binary
-  - ps: (new-object net.webclient).DownloadFile(
-        $env:JULIA_URL,
-        "C:\projects\julia-binary.exe")
-# Run installer silently, output to C:\projects\julia
-  - C:\projects\julia-binary.exe /S /D=C:\projects\julia
+  - ps: iex ((new-object net.webclient).DownloadString("https://raw.githubusercontent.com/JuliaCI/Appveyor.jl/version-1/bin/install.ps1"))
 
 build_script:
-# Need to convert from shallow to complete for Pkg.clone to work
-  - IF EXIST .git\shallow (git fetch --unshallow)
-  - C:\projects\julia\bin\julia -e "versioninfo();
-      Pkg.clone(pwd(), \"StochasticDiffEq\"); Pkg.build(\"StochasticDiffEq\")"
+  - echo "%JL_BUILD_SCRIPT%"
+  - C:\julia\bin\julia -e "%JL_BUILD_SCRIPT%"
 
 test_script:
-  - C:\projects\julia\bin\julia -e "Pkg.test(\"StochasticDiffEq\")"
+  - echo "%JL_TEST_SCRIPT%"
+  - C:\julia\bin\julia -e "%JL_TEST_SCRIPT%"
+
+# # Uncomment to support code coverage upload. Should only be enabled for packages
+# # which would have coverage gaps without running on Windows
+# on_success:
+#   - echo "%JL_CODECOV_SCRIPT%"
+#   - C:\julia\bin\julia -e "%JL_CODECOV_SCRIPT%"

--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -236,8 +236,11 @@ end
 function apply_discrete_callback!(integrator::SDEIntegrator,callback::DiscreteCallback)
   saved_in_cb = false
   if callback.condition(integrator.u,integrator.t,integrator)
+    # handle saveat
+    savevalues!(integrator)
     if callback.save_positions[1]
-      savevalues!(integrator,true)
+      # if already saved then skip saving
+      last(integrator.sol.t) == integrator.t || savevalues!(integrator,true)
       saved_in_cb = true
     end
     integrator.u_modified = true

--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -196,8 +196,12 @@ function apply_callback!(integrator,callback::ContinuousCallback,cb_time,prev_si
     change_t_via_interpolation!(integrator,integrator.tprev+cb_time)
   end
 
+  # handle saveat
+  savevalues!(integrator)
+
   if callback.save_positions[1]
-    savevalues!(integrator,true)
+    # if already saved then skip saving
+    last(integrator.sol.t) == integrator.t || savevalues!(integrator,true)
     saved_in_cb = true
   end
 

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,6 +1,5 @@
 DiffEqDevTools
 DiffEqProblemLibrary
 ParameterizedFunctions
-SpecialMatrices
 StaticArrays
 DiffEqCallbacks

--- a/test/events_test.jl
+++ b/test/events_test.jl
@@ -17,6 +17,7 @@ function affect_neg!(integrator)
   integrator.u[2] = -integrator.u[2]
 end
 
+# Continuous callback
 callback = ContinuousCallback(condtion,affect!,affect_neg!)
 
 u0 = [50.0,0.0]
@@ -43,3 +44,16 @@ prob = SDEProblem(f,g,u0,tspan)
 sol = solve(prob,SRIW1(),callback=callback)
 
 sol = solve(prob,EM(),callback=callback,dt=1/4)
+
+# Discrete callback
+tstop = [5.;8.]
+condition = (u,t,integrator) -> t in tstop
+affect! = (integrator) -> integrator.u .= 1.0
+save_positions = (true,true)
+callback = DiscreteCallback(condition, affect!, save_positions=save_positions)
+sol = solve(prob, SRIW1(), callback=callback, tstops=tstop, saveat=tstop)
+@test count(x->x==tstop[1], sol.t) == 2
+@test count(x->x==tstop[2], sol.t) == 2
+sol = solve(prob, SRIW1(), callback=callback, tstops=tstop, saveat=prevfloat.(tstop))
+@test count(x->x==tstop[1], sol.t) == 2
+@test count(x->x==tstop[2], sol.t) == 2

--- a/test/events_test.jl
+++ b/test/events_test.jl
@@ -47,13 +47,13 @@ sol = solve(prob,EM(),callback=callback,dt=1/4)
 
 # Discrete callback
 tstop = [5.;8.]
-condition = (u,t,integrator) -> t in tstop
-affect! = (integrator) -> integrator.u .= 1.0
+condition_dc = (u,t,integrator) -> t in tstop
+affect!_dc = (integrator) -> integrator.u .= 1.0
 save_positions = (true,true)
-callback = DiscreteCallback(condition, affect!, save_positions=save_positions)
-sol = solve(prob, SRIW1(), callback=callback, tstops=tstop, saveat=tstop)
+callback_dc = DiscreteCallback(condition_dc, affect!_dc, save_positions=save_positions)
+sol = solve(prob, SRIW1(), callback=callback_dc, tstops=tstop, saveat=tstop)
 @test count(x->x==tstop[1], sol.t) == 2
 @test count(x->x==tstop[2], sol.t) == 2
-sol = solve(prob, SRIW1(), callback=callback, tstops=tstop, saveat=prevfloat.(tstop))
+sol = solve(prob, SRIW1(), callback=callback_dc, tstops=tstop, saveat=prevfloat.(tstop))
 @test count(x->x==tstop[1], sol.t) == 2
 @test count(x->x==tstop[2], sol.t) == 2

--- a/test/events_test.jl
+++ b/test/events_test.jl
@@ -27,6 +27,13 @@ sol = solve(prob,SRIW1(),callback=callback,adaptive=false,dt=3/4)
 
 @test minimum(sol[1,:]) > -1e-12 && minimum(sol[1,:]) < 1e-12
 
+sol = solve(prob,SRIW1(),callback=callback,save_everystep=false)
+t = sol.t[end÷2] # this is the callback time point
+sol = solve(prob,SRIW1(),callback=callback,saveat=t)
+@test count(x->x==t, sol.t) == 2
+sol = solve(prob,SRIW1(),callback=callback,saveat=t-eps(t))
+@test count(x->x==t, sol.t) == 2
+
 function g(du,u,p,t)
   du[2] = .125*u[2]
 end

--- a/test/multivariate_geometric.jl
+++ b/test/multivariate_geometric.jl
@@ -1,4 +1,4 @@
-using DiffEqBase, StochasticDiffEq, DiffEqDevTools, Test, LinearAlgebra
+using DiffEqBase, StochasticDiffEq, DiffEqDevTools, Test, LinearAlgebra, Random
 
 u0 = ones(2)
 A = [-3/2 1/20
@@ -26,8 +26,10 @@ sol2 = solve(prob2,EM(),dt=1/100)
 
 dts = 1 ./ 2 .^ (14:-1:7) #14->7 good plot
 
-sim  = test_convergence(dts,prob2,EM(),numMonte=Int(5e1))
-@test_broken abs(sim.𝒪est[:l2]-0.5) < 0.1
+println("First Test")
+Random.seed!(100)
+sim  = test_convergence(dts,prob2,EM(),numMonte=100)
+@test abs(sim.𝒪est[:l2]-0.5) < 0.1
 
 # using Plots; plot(sim)
 
@@ -57,7 +59,9 @@ sol2 = solve(prob2,EM(),dt=1/100)
 
 dts = 1 ./ 2 .^ (17:-1:10) #14->7 good plot
 
-sim  = test_convergence(dts,prob2,EM(),numMonte=Int(5e1))
+println("Second Test")
+Random.seed!(100)
+sim  = test_convergence(dts,prob2,EM(),numMonte=50)
 @test_broken abs(sim.𝒪est[:l2]-0.5) < 0.1
 
 # using Plots; plot(sim)

--- a/test/multivariate_geometric.jl
+++ b/test/multivariate_geometric.jl
@@ -61,7 +61,7 @@ dts = 1 ./ 2 .^ (17:-1:10) #14->7 good plot
 
 println("Second Test")
 Random.seed!(100)
-sim  = test_convergence(dts,prob2,EM(),numMonte=50)
+sim  = test_convergence(dts,prob2,EM(),numMonte=100)
 @test_broken abs(sim.𝒪est[:l2]-0.5) < 0.1
 
 # using Plots; plot(sim)

--- a/test/multivariate_geometric.jl
+++ b/test/multivariate_geometric.jl
@@ -27,7 +27,7 @@ sol2 = solve(prob2,EM(),dt=1/100)
 dts = 1 ./ 2 .^ (14:-1:7) #14->7 good plot
 
 sim  = test_convergence(dts,prob2,EM(),numMonte=Int(5e1))
-@test abs(sim.𝒪est[:l2]-0.5) < 0.1
+@test_broken abs(sim.𝒪est[:l2]-0.5) < 0.1
 
 # using Plots; plot(sim)
 

--- a/test/multivariate_geometric.jl
+++ b/test/multivariate_geometric.jl
@@ -22,9 +22,8 @@ end
 prob2 = SDEProblem(f,σ,u0,(0.0,1.0),noise_rate_prototype=rand(2,2))
 
 sol2 = solve(prob2,EM(),dt=1/100)
-# using Plots; plot(sol2,plot_analytic=true)
 
-dts = 1 ./ 2 .^ (14:-1:7) #14->7 good plot
+dts = 1 ./ 2 .^ (14:-1:7)
 
 println("First Test")
 Random.seed!(100)
@@ -55,13 +54,13 @@ end
 prob2 = SDEProblem(f,σ,u0,(0.0,1.0),noise_rate_prototype=rand(2,2))
 
 sol2 = solve(prob2,EM(),dt=1/100)
-# using Plots; plot(sol2,plot_analytic=true)
 
-dts = 1 ./ 2 .^ (17:-1:10) #14->7 good plot
+dts = 1 ./ 2 .^ (14:-1:7)
 
 println("Second Test")
 Random.seed!(100)
-sim  = test_convergence(dts,prob2,EM(),numMonte=100)
-@test_broken abs(sim.𝒪est[:l2]-0.5) < 0.1
+sim  = test_convergence(dts,prob2,EM(),numMonte=50)
+# Superconvergence
+@test abs(sim.𝒪est[:l2]-1.0) < 0.1
 
 # using Plots; plot(sim)

--- a/test/multivariate_geometric.jl
+++ b/test/multivariate_geometric.jl
@@ -1,4 +1,4 @@
-using DiffEqBase, StochasticDiffEq, DiffEqDevTools, Test
+using DiffEqBase, StochasticDiffEq, DiffEqDevTools, Test, LinearAlgebra
 
 u0 = ones(2)
 A = [-3/2 1/20
@@ -22,19 +22,17 @@ end
 prob2 = SDEProblem(f,σ,u0,(0.0,1.0),noise_rate_prototype=rand(2,2))
 
 sol2 = solve(prob2,EM(),dt=1/100)
-using Plots; plot(sol2,plot_analytic=true)
+# using Plots; plot(sol2,plot_analytic=true)
 
-dts = 1./2.^(14:-1:7) #14->7 good plot
+dts = 1 ./ 2 .^ (14:-1:7) #14->7 good plot
 
 sim  = test_convergence(dts,prob2,EM(),numMonte=Int(5e1))
 @test abs(sim.𝒪est[:l2]-0.5) < 0.1
 
-using Plots; plot(sim)
+# using Plots; plot(sim)
 
-
-using SpecialMatrices
 u0 = rand(2)
-A = Strang(2)
+A = [2.0 -1.0; -1.0 2.0]
 B = [1/5 1/100
     1/100 1/5]
 
@@ -55,11 +53,11 @@ end
 prob2 = SDEProblem(f,σ,u0,(0.0,1.0),noise_rate_prototype=rand(2,2))
 
 sol2 = solve(prob2,EM(),dt=1/100)
-using Plots; plot(sol2,plot_analytic=true)
+# using Plots; plot(sol2,plot_analytic=true)
 
-dts = 1./2.^(17:-1:10) #14->7 good plot
+dts = 1 ./ 2 .^ (17:-1:10) #14->7 good plot
 
 sim  = test_convergence(dts,prob2,EM(),numMonte=Int(5e1))
-@test abs(sim.𝒪est[:l2]-0.5) < 0.1
+@test_broken abs(sim.𝒪est[:l2]-0.5) < 0.1
 
-using Plots; plot(sim)
+# using Plots; plot(sim)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -55,6 +55,6 @@ is_APPVEYOR = ( Sys.iswindows() && haskey(ENV,"APPVEYOR") )
     @time @testset "IIF Convergence Tests" begin include("iif_methods.jl") end
     LONGER_TESTS && @time @testset "Weak Convergence Tests" begin include("weak_convergence.jl") end
     @time @testset "Cummutative Noise Methods Tests" begin include("commutative_tests.jl") end
-    LONGER_TESTS && @time @testset "Multivariate Geometric Tests" begin include("multivariate_geometric.jl") end
+    @time @testset "Multivariate Geometric Tests" begin include("multivariate_geometric.jl") end
   end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -55,5 +55,6 @@ is_APPVEYOR = ( Sys.iswindows() && haskey(ENV,"APPVEYOR") )
     @time @testset "IIF Convergence Tests" begin include("iif_methods.jl") end
     LONGER_TESTS && @time @testset "Weak Convergence Tests" begin include("weak_convergence.jl") end
     @time @testset "Cummutative Noise Methods Tests" begin include("commutative_tests.jl") end
+    @time @testset "Multivariate Geometric Tests" begin include("multivariate_geometric.jl") end
   end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -55,6 +55,6 @@ is_APPVEYOR = ( Sys.iswindows() && haskey(ENV,"APPVEYOR") )
     @time @testset "IIF Convergence Tests" begin include("iif_methods.jl") end
     LONGER_TESTS && @time @testset "Weak Convergence Tests" begin include("weak_convergence.jl") end
     @time @testset "Cummutative Noise Methods Tests" begin include("commutative_tests.jl") end
-    @time @testset "Multivariate Geometric Tests" begin include("multivariate_geometric.jl") end
+    LONGER_TESTS && @time @testset "Multivariate Geometric Tests" begin include("multivariate_geometric.jl") end
   end
 end

--- a/test/utility_tests.jl
+++ b/test/utility_tests.jl
@@ -3,7 +3,7 @@ using StochasticDiffEq, LinearAlgebra, SparseArrays, Random, Test, DiffEqOperato
 
 @testset "Derivative Utilities" begin
   @testset "WOperator" begin
-    srand(0); y = zeros(2); b = rand(2)
+    Random.seed!(0); y = zeros(2); b = rand(2)
     mm = I; _J = rand(2,2)
     W = WOperator(mm, 1.0, DiffEqArrayOperator(_J))
     set_gamma!(W, 2.0)
@@ -58,11 +58,11 @@ using StochasticDiffEq, LinearAlgebra, SparseArrays, Random, Test, DiffEqOperato
 
     for Alg in [ImplicitEM, ISSEM]
       println(Alg)
-      srand(0); sol1 = solve(prob1, Alg(theta=1); adaptive=false, dt=0.01)
-      srand(0); sol2 = solve(prob2, Alg(theta=1); adaptive=false, dt=0.01)
+      Random.seed!(0); sol1 = solve(prob1, Alg(theta=1); adaptive=false, dt=0.01)
+      Random.seed!(0); sol2 = solve(prob2, Alg(theta=1); adaptive=false, dt=0.01)
       @test sol1(1.0) ≈ sol2(1.0)
-      srand(0); sol1_ip = solve(prob1_ip, Alg(theta=1); adaptive=false, dt=0.01)
-      srand(0); sol2_ip = solve(prob2_ip, Alg(theta=1,linsolve=LinSolveFactorize(lu)); adaptive=false, dt=0.01)
+      Random.seed!(0); sol1_ip = solve(prob1_ip, Alg(theta=1); adaptive=false, dt=0.01)
+      Random.seed!(0); sol2_ip = solve(prob2_ip, Alg(theta=1,linsolve=LinSolveFactorize(lu)); adaptive=false, dt=0.01)
       @test sol1_ip(1.0) ≈ sol2_ip(1.0)
     end
 
@@ -74,11 +74,11 @@ using StochasticDiffEq, LinearAlgebra, SparseArrays, Random, Test, DiffEqOperato
     prob2_ip = SDEProblem(SDEFunction(_f_ip, _g_ip; jac_prototype=jac_prototype), _g_ip, u0, tspan)
 
     println(SKenCarp)
-    srand(0); sol1 = solve(prob1, SKenCarp(); adaptive=false, dt=0.01)
-    srand(0); sol2 = solve(prob2, SKenCarp(); adaptive=false, dt=0.01)
+    Random.seed!(0); sol1 = solve(prob1, SKenCarp(); adaptive=false, dt=0.01)
+    Random.seed!(0); sol2 = solve(prob2, SKenCarp(); adaptive=false, dt=0.01)
     @test sol1(1.0) ≈ sol2(1.0)
-    srand(0); sol1_ip = solve(prob1_ip, SKenCarp(); adaptive=false, dt=0.01)
-    srand(0); sol2_ip = solve(prob2_ip, SKenCarp(linsolve=LinSolveFactorize(lu)); adaptive=false, dt=0.01)
+    Random.seed!(0); sol1_ip = solve(prob1_ip, SKenCarp(); adaptive=false, dt=0.01)
+    Random.seed!(0); sol2_ip = solve(prob2_ip, SKenCarp(linsolve=LinSolveFactorize(lu)); adaptive=false, dt=0.01)
     @test sol1_ip(1.0) ≈ sol2_ip(1.0)
   end
 end


### PR DESCRIPTION
The SpecialMatrices package is no longer available due to the recent package compatibility capping and it is preventing tests from executing. The only affected test script is multivariate_geometric.jl which for some reason is not included in the test suite. I have added it and also made some minor fixes to the test script (note that the last test seems to be broken).