### PR TITLE
Use `internalnorm` instead of `abs` in lamba.jl

### DIFF
--- a/src/perform_step/lamba.jl
+++ b/src/perform_step/lamba.jl
@@ -76,7 +76,7 @@ end
 
 
     @tight_loop_macros for (i,atol,rtol) in zip(eachindex(u),Iterators.cycle(integrator.opts.abstol),Iterators.cycle(integrator.opts.reltol))
-      @inbounds tmp[i] = (tmp[i])/(atol + max(abs(uprev[i]),abs(u[i]))*rtol)
+      @inbounds tmp[i] = (tmp[i])/(atol + max(integrator.opts.internalnorm(uprev[i]),integrator.opts.internalnorm(u[i]))*rtol)
     end
     integrator.EEst = integrator.opts.internalnorm(tmp)
   end
@@ -173,7 +173,7 @@ end
 
 
     @tight_loop_macros for (i,atol,rtol) in zip(eachindex(u),Iterators.cycle(integrator.opts.abstol),Iterators.cycle(integrator.opts.reltol))
-      @inbounds tmp[i] = (tmp[i])/(atol + max(abs(uprev[i]),abs(u[i]))*rtol)
+      @inbounds tmp[i] = (tmp[i])/(atol + max(integrator.opts.internalnorm(uprev[i]),integrator.opts.internalnorm(u[i]))*rtol)
     end
     integrator.EEst = integrator.opts.internalnorm(tmp)
   end

--- a/src/perform_step/lamba.jl
+++ b/src/perform_step/lamba.jl
@@ -21,7 +21,7 @@
     ggprime = (integrator.g(utilde,p,t).-L)./(integrator.sqdt)
     En = ggprime.*(W.dW.^2 .- dt)./2
 
-    integrator.EEst = integrator.opts.internalnorm((Ed + En)/((integrator.opts.abstol + max.(abs(uprev),abs(u))*integrator.opts.reltol)))
+    integrator.EEst = integrator.opts.internalnorm((Ed + En)/((integrator.opts.abstol + max.(integrator.opts.internalnorm(uprev),integrator.opts.internalnorm(u))*integrator.opts.reltol)))
   end
 
   integrator.u = u
@@ -111,7 +111,7 @@ end
     ggprime = (integrator.g(utilde,p,t).-L)./(integrator.sqdt)
     En = ggprime.*(W.dW.^2)./2
 
-    integrator.EEst = integrator.opts.internalnorm((Ed + En)/((integrator.opts.abstol + max.(abs(uprev),abs(u))*integrator.opts.reltol)))
+    integrator.EEst = integrator.opts.internalnorm((Ed + En)/((integrator.opts.abstol + max.(integrator.opts.internalnorm(uprev),integrator.opts.internalnorm(u))*integrator.opts.reltol)))
   end
 
   integrator.u = u

--- a/src/perform_step/low_order.jl
+++ b/src/perform_step/low_order.jl
@@ -146,7 +146,7 @@ end
   end
   @. u = K+L*W.dW + tmp
   if integrator.opts.adaptive
-    @. tmp = (tmp)/(integrator.opts.abstol + max(abs(uprev),abs(u))*integrator.opts.reltol)
+    @. tmp = (tmp)/(integrator.opts.abstol + max(integrator.opts.internalnorm(uprev),integrator.opts.internalnorm(u))*integrator.opts.reltol)
     integrator.EEst = integrator.opts.internalnorm(tmp)
   end
   integrator.u = u
@@ -176,7 +176,7 @@ end
     integrator.f(du2,K,p,t+dt)
     @. tmp += integrator.opts.internalnorm(dt*(du2 - du1)/2)
     @tight_loop_macros for (i,atol,rtol) in zip(eachindex(u),Iterators.cycle(integrator.opts.abstol),Iterators.cycle(integrator.opts.reltol))
-      @inbounds tmp[i] = (tmp[i])/(atol + max(abs(uprev[i]),abs(u[i]))*rtol)
+      @inbounds tmp[i] = (tmp[i])/(atol + max(integrator.opts.internalnorm(uprev[i]),integrator.opts.internalnorm(u[i]))*rtol)
     end
     integrator.EEst = integrator.opts.internalnorm(tmp)
   end
@@ -222,7 +222,7 @@ end
       @. tmp = integrator.opts.internalnorm(dt*(du2 - du1)/2) + En
 
       @tight_loop_macros for (i,atol,rtol) in zip(eachindex(u),Iterators.cycle(integrator.opts.abstol),Iterators.cycle(integrator.opts.reltol))
-        @inbounds tmp[i] = (tmp[i])/(atol + max(abs(uprev[i]),abs(u[i]))*rtol)
+        @inbounds tmp[i] = (tmp[i])/(atol + max(integrator.opts.internalnorm(uprev[i]),integrator.opts.internalnorm(u[i]))*rtol)
       end
       integrator.EEst = integrator.opts.internalnorm(tmp)
 

--- a/src/perform_step/sdirk.jl
+++ b/src/perform_step/sdirk.jl
@@ -241,7 +241,7 @@ end
 
     elseif typeof(cache) <: ImplicitRKMilCache
       # gtmp3 is ggprime
-      @. dz = abs(dW^3)*integrator.opts.internalnorm(gtmp3)^2 / 6
+      @. dz = integrator.opts.internalnorm(dW^3)*integrator.opts.internalnorm(gtmp3)^2 / 6
     end
 
     @tight_loop_macros for (i,atol,rtol,δ) in zip(eachindex(u),Iterators.cycle(integrator.opts.abstol),


### PR DESCRIPTION
Permits use of the Lamba integrators with complex arrays.

Partially addresses https://github.com/JuliaDiffEq/DifferentialEquations.jl/issues/401