### PR TITLE
Improve computation of residuals

### DIFF
--- a/src/perform_step/kencarp.jl
+++ b/src/perform_step/kencarp.jl
@@ -128,7 +128,10 @@
 
     E₁ = z₁ + z₂ + z₃ + z₄
 
-    integrator.EEst = integrator.opts.internalnorm((integrator.opts.delta*E₁+E₂)./(integrator.opts.abstol + max.(integrator.opts.internalnorm.(uprev),integrator.opts.internalnorm.(u))*integrator.opts.reltol))
+    resids = calculate_residuals(E₁, E₂, uprev, u, integrator.opts.abstol,
+                                 integrator.opts.reltol, integrator.opts.delta,
+                                 integrator.opts.internalnorm)
+    integrator.EEst = integrator.opts.internalnorm(resids)
   end
 
   integrator.u = u
@@ -340,10 +343,9 @@ end
 
     @. E₁ = z₁ + z₂ + z₃ + z₄
 
-    @tight_loop_macros for (i,atol,rtol,δ) in zip(eachindex(u),Iterators.cycle(integrator.opts.abstol),
-                       Iterators.cycle(integrator.opts.reltol),Iterators.cycle(integrator.opts.delta))
-      @inbounds tmp[i] = (δ*E₁[i]+E₂[i])/(atol + max(integrator.opts.internalnorm(uprev[i]),integrator.opts.internalnorm(u[i]))*rtol)
-    end
+    calculate_residuals!(tmp, E₁, E₂, uprev, u, integrator.opts.abstol,
+                         integrator.opts.reltol, integrator.opts.delta,
+                         integrator.opts.internalnorm)
     integrator.EEst = integrator.opts.internalnorm(tmp)
   end
 end

--- a/src/perform_step/lamba.jl
+++ b/src/perform_step/lamba.jl
@@ -21,7 +21,10 @@
     ggprime = (integrator.g(utilde,p,t).-L)./(integrator.sqdt)
     En = ggprime.*(W.dW.^2 .- dt)./2
 
-    integrator.EEst = integrator.opts.internalnorm((Ed + En)/((integrator.opts.abstol + max.(integrator.opts.internalnorm(uprev),integrator.opts.internalnorm(u))*integrator.opts.reltol)))
+    resids = calculate_residuals(Ed, En, uprev, u, integrator.opts.abstol,
+                                 integrator.opts.reltol, integrator.opts.delta,
+                                 integrator.opts.internalnorm)
+    integrator.EEst = integrator.opts.internalnorm(resids)
   end
 
   integrator.u = u
@@ -72,12 +75,10 @@ end
 
     # Ed
     integrator.f(du2,K,p,t+dt)
-    @. tmp += integrator.opts.internalnorm(dt*(du2 - du1)/2)
+    @. tmp += integrator.opts.internalnorm(integrator.opts.delta * dt * (du2 - du1) / 2)
 
-
-    @tight_loop_macros for (i,atol,rtol) in zip(eachindex(u),Iterators.cycle(integrator.opts.abstol),Iterators.cycle(integrator.opts.reltol))
-      @inbounds tmp[i] = (tmp[i])/(atol + max(integrator.opts.internalnorm(uprev[i]),integrator.opts.internalnorm(u[i]))*rtol)
-    end
+    calculate_residuals!(tmp, tmp, uprev, u, integrator.opts.abstol,
+                         integrator.opts.reltol, integrator.opts.internalnorm)
     integrator.EEst = integrator.opts.internalnorm(tmp)
   end
 end
@@ -111,7 +112,10 @@ end
     ggprime = (integrator.g(utilde,p,t).-L)./(integrator.sqdt)
     En = ggprime.*(W.dW.^2)./2
 
-    integrator.EEst = integrator.opts.internalnorm((Ed + En)/((integrator.opts.abstol + max.(integrator.opts.internalnorm(uprev),integrator.opts.internalnorm(u))*integrator.opts.reltol)))
+    resids = calculate_residuals(Ed, En, uprev, u, integrator.opts.abstol,
+                                 integrator.opts.reltol, integrator.opts.delta,
+                                 integrator.opts.internalnorm)
+    integrator.EEst = integrator.opts.internalnorm(resids)
   end
 
   integrator.u = u
@@ -169,12 +173,10 @@ end
 
     # Ed
     integrator.f(du2,K,p,t+dt)
-    @. tmp += integrator.opts.internalnorm(dt*(du2 - du1)/2)
+    @. tmp += integrator.opts.internalnorm(integrator.opts.delta * dt * (du2 - du1) / 2)
 
-
-    @tight_loop_macros for (i,atol,rtol) in zip(eachindex(u),Iterators.cycle(integrator.opts.abstol),Iterators.cycle(integrator.opts.reltol))
-      @inbounds tmp[i] = (tmp[i])/(atol + max(integrator.opts.internalnorm(uprev[i]),integrator.opts.internalnorm(u[i]))*rtol)
-    end
+    calculate_residuals!(tmp, tmp, uprev, u, integrator.opts.abstol,
+                         integrator.opts.reltol, integrator.opts.internalnorm)
     integrator.EEst = integrator.opts.internalnorm(tmp)
   end
 end

--- a/src/perform_step/sdirk.jl
+++ b/src/perform_step/sdirk.jl
@@ -84,8 +84,10 @@
              integrator.opts.internalnorm.(ggprime).^2 ./ 6
     end
 
-    tmp = Ed+En
-    integrator.EEst = integrator.opts.internalnorm(tmp./(integrator.opts.abstol + max.(integrator.opts.internalnorm.(uprev),integrator.opts.internalnorm.(u))*integrator.opts.reltol))
+    resids = calculate_residuals(Ed, En, uprev, u, integrator.opts.abstol,
+                                 integrator.opts.reltol, integrator.opts.delta,
+                                 integrator.opts.internalnorm)
+    integrator.EEst = integrator.opts.internalnorm(resids)
   end
 
   integrator.u = u
@@ -244,10 +246,9 @@ end
       @. dz = integrator.opts.internalnorm(dW^3)*integrator.opts.internalnorm(gtmp3)^2 / 6
     end
 
-    @tight_loop_macros for (i,atol,rtol,δ) in zip(eachindex(u),Iterators.cycle(integrator.opts.abstol),
-                            Iterators.cycle(integrator.opts.reltol),Iterators.cycle(integrator.opts.delta))
-      @inbounds tmp[i] = (k[i]+dz[i])/(atol + max(integrator.opts.internalnorm(uprev[i]),integrator.opts.internalnorm(u[i]))*rtol)
-    end
+    calculate_residuals!(tmp, k, dz, uprev, u, integrator.opts.abstol,
+                         integrator.opts.reltol, integrator.opts.delta,
+                         integrator.opts.internalnorm)
     integrator.EEst = integrator.opts.internalnorm(tmp)
 
   end


### PR DESCRIPTION
This PR changes the computation of residuals to a slight modification of the implementation in OrdinaryDiffEq (see https://github.com/JuliaDiffEq/OrdinaryDiffEq.jl/pull/574). Moreover, it adds adaptivity parameter `delta` (see http://docs.juliadiffeq.org/latest/solvers/sde_solve.html#Special-Keyword-Arguments-1) to all adaptive algorithms.

This PR fixes https://github.com/JuliaDiffEq/StochasticDiffEq.jl/issues/123, the example
```julia
using StochasticDiffEq

f(u,p,t) = 0.4.*u
g(u,p,t) = 0.0.*u
u0 = [1., 1.]
prob = SDEProblem(f,g,u0,(0.0,1.0))
solve(prob, SKenCarp())
```
works now.

Additionally the PR fixes similar errors for algorithms `SRA`, `SRA1`, and `SRA2` that were mentioned in https://github.com/JuliaDiffEq/DifferentialEquations.jl/issues/401#issuecomment-447433277, the example
```julia
using StochasticDiffEq, DiffEqNoiseProcess

function numerical_sol(solver)
    f(u,p,t) = u
    g(u,p,t) = u
    u₀=[1.0im 2.0im; 3.0im 4.0im]
    W = WienerProcess(0., 0., 0.)
    tspan = (0.0, 1.0)
    prob = SDEProblem(f, g, u₀, tspan, noise=W)
    solve(prob, solver)
end
```
doesn't fail anymore for these algorithms.