### PR TITLE
Fix deprecation of binary_minheap and binary_maxheap

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -2,7 +2,7 @@ julia 1.0
 Parameters 0.5.0
 DiffEqBase 4.29.0
 RecursiveArrayTools 0.13.0
-DataStructures 0.4.6
+DataStructures 0.15.0
 DiffEqNoiseProcess
 NLsolve 0.14.1
 ForwardDiff 0.7.0

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -424,9 +424,9 @@ function tstop_saveat_disc_handling(tstops,saveat,d_discontinuities,tdir,tspan,t
   end
 
   if tdir>0
-    tstops_internal = binary_minheap(tstops_vec)
+    tstops_internal = BinaryMinHeap(tstops_vec)
   else
-    tstops_internal = binary_maxheap(tstops_vec)
+    tstops_internal = BinaryMaxHeap(tstops_vec)
   end
 
   if typeof(saveat) <: Number
@@ -442,17 +442,17 @@ function tstop_saveat_disc_handling(tstops,saveat,d_discontinuities,tdir,tspan,t
   end
 
   if tdir>0
-    saveat_internal = binary_minheap(saveat_vec)
+    saveat_internal = BinaryMinHeap(saveat_vec)
   else
-    saveat_internal = binary_maxheap(saveat_vec)
+    saveat_internal = BinaryMaxHeap(saveat_vec)
   end
 
   d_discontinuities_vec = vec(collect(d_discontinuities))
 
   if tdir>0
-    d_discontinuities_internal = binary_minheap(d_discontinuities_vec)
+    d_discontinuities_internal = BinaryMinHeap(d_discontinuities_vec)
   else
-    d_discontinuities_internal = binary_maxheap(d_discontinuities_vec)
+    d_discontinuities_internal = BinaryMaxHeap(d_discontinuities_vec)
   end
   tstops_internal,saveat_internal,d_discontinuities_internal
 end


### PR DESCRIPTION
Updates the deprecated `binary_minheap` and `binary_maxheap`. This PR is just a copy of https://github.com/JuliaDiffEq/OrdinaryDiffEq.jl/pull/593.