### PR TITLE
Clean and update solve.jl

### DIFF
--- a/src/StochasticDiffEq.jl
+++ b/src/StochasticDiffEq.jl
@@ -24,10 +24,10 @@ module StochasticDiffEq
 
   import ForwardDiff.Dual
 
-  import DiffEqBase: __solve, solve!, __init, step!, build_solution, initialize!, DEAlgorithm,
+  import DiffEqBase: step!, initialize!, DEAlgorithm,
                      AbstractSDEAlgorithm, AbstractRODEAlgorithm, DEIntegrator, AbstractDiffEqInterpolation,
                      DECache, AbstractSDEIntegrator, AbstractRODEIntegrator, AbstractContinuousCallback,
-                     @def, AbstractRODESolution, AbstractSDEProblem, AbstractRODEProblem, Tableau
+                     Tableau
 
   # Integrator Interface
   import DiffEqBase: resize!,deleteat!,addat!,full_cache,user_cache,u_cache,du_cache,
@@ -35,10 +35,9 @@ module StochasticDiffEq
                      resize_non_user_cache!,deleteat_non_user_cache!,addat_non_user_cache!,
                      terminate!,get_du, get_dt,get_proposed_dt,set_proposed_dt!,
                      u_modified!,savevalues!,add_tstop!,add_saveat!,set_reltol!,
-                     set_abstol!, postamble!, last_step_failed, is_diagonal_noise,
-                     has_analytic, has_invW, has_jac, solution_new_retcode
+                     set_abstol!, postamble!, last_step_failed, has_invW, has_jac
 
-  using DiffEqBase: check_error!
+  using DiffEqBase: check_error!, is_diagonal_noise
 
   const CompiledFloats = Union{Float32,Float64}
 

--- a/src/composite_solution.jl
+++ b/src/composite_solution.jl
@@ -1,4 +1,4 @@
-struct RODECompositeSolution{T,N,uType,uType2,EType,tType,randType,P,A,IType} <: AbstractRODESolution{T,N}
+struct RODECompositeSolution{T,N,uType,uType2,EType,tType,randType,P,A,IType} <: DiffEqBase.AbstractRODESolution{T,N}
   u::uType
   u_analytic::uType2
   errors::EType
@@ -16,8 +16,8 @@ end
 (sol::RODECompositeSolution)(t,deriv::Type=Val{0};idxs=nothing,continuity=:left) = sol.interp(t,idxs,deriv,sol.prob.p,continuity)
 (sol::RODECompositeSolution)(v,t,deriv::Type=Val{0};idxs=nothing,continuity=:left) = sol.interp(v,t,idxs,deriv,sol.prob.p,continuity)
 
-function build_solution(
-        prob::AbstractRODEProblem,
+function DiffEqBase.build_solution(
+        prob::DiffEqBase.AbstractRODEProblem,
         alg::Union{StochasticDiffEqCompositeAlgorithm,
                    StochasticDiffEqRODECompositeAlgorithm},t,u;
         W=[],timeseries_errors=length(u)>2,
@@ -40,7 +40,7 @@ function build_solution(
     f = prob.f
   end
 
-  if has_analytic(f)
+  if DiffEqBase.has_analytic(f)
     u_analytic = Vector{typeof(prob.u0)}()
     errors = Dict{Symbol,real(eltype(prob.u0))}()
     sol = RODECompositeSolution{T,N,typeof(u),typeof(u_analytic),typeof(errors),typeof(t),typeof(W),

--- a/src/dense.jl
+++ b/src/dense.jl
@@ -78,7 +78,7 @@ function sde_interpolant(Θ,dt,u0::AbstractArray,u1,idxs,deriv::Type)
     S = promote_type(typeof(oneunit(Θ) * oneunit(eltype(u0))), # Θ*u0
                      typeof(oneunit(eltype(u0)) / oneunit(dt))) # u1/dt
 
-    if typeof(idxs) <: Nothing
+    if idxs === nothing
       out = similar(u0, S)
     else
       out = similar(u0, S, axes(idxs))

--- a/src/integrators/integrator_interface.jl
+++ b/src/integrators/integrator_interface.jl
@@ -150,7 +150,7 @@ end
 
 function resize_non_user_cache!(integrator::SDEIntegrator,cache,i)
   bot_idx = length(integrator.u) + 1
-  if DiffEqBase.is_diagonal_noise(integrator.sol.prob)
+  if is_diagonal_noise(integrator.sol.prob)
     resize_noise!(integrator,cache,bot_idx,i)
     for c in rand_cache(integrator)
       resize!(c,i)
@@ -179,7 +179,7 @@ function addat!(integrator::SDEIntegrator,idxs)
 end
 
 function deleteat_non_user_cache!(integrator::SDEIntegrator,cache,idxs)
-  if DiffEqBase.is_diagonal_noise(integrator.sol.prob)
+  if is_diagonal_noise(integrator.sol.prob)
     deleteat_noise!(integrator,cache,idxs)
     for c in rand_cache(integrator)
       deleteat!(c,idxs)
@@ -188,7 +188,7 @@ function deleteat_non_user_cache!(integrator::SDEIntegrator,cache,idxs)
 end
 
 function addat_non_user_cache!(integrator::SDEIntegrator,cache,idxs)
-  if DiffEqBase.is_diagonal_noise(integrator.sol.prob)
+  if is_diagonal_noise(integrator.sol.prob)
     addat_noise!(integrator,cache,idxs)
     for c in rand_cache(integrator)
       addat!(c,idxs)

--- a/src/integrators/integrator_utils.jl
+++ b/src/integrators/integrator_utils.jl
@@ -62,12 +62,6 @@ end
 last_step_failed(integrator::SDEIntegrator) =
   integrator.last_stepfail && !integrator.opts.adaptive
 
-@def sde_exit_conditions begin
-  if check_error!(integrator) != :Success
-    return integrator.sol
-  end
-end
-
 @inline function savevalues!(integrator::SDEIntegrator,force_save=false)::Tuple{Bool,Bool}
   saved, savedexactly = false, false
   !integrator.opts.save_on && return saved, savedexactly

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -131,8 +131,6 @@ function DiffEqBase.__init(
   dtmax > zero(dtmax) && tdir < 0 && (dtmax *= tdir) # Allow positive dtmax, but auto-convert
   # dtmin is all abs => does not care about sign already.
 
-  order = typeof(alg) <: SRI || typeof(alg) <: SRA ? alg.tableau.order : alg_order(alg)
-
   if isinplace(prob) && typeof(u) <: AbstractArray && eltype(u) <: Number && uBottomEltypeNoUnits == uBottomEltype # Could this be more efficient for other arrays?
     if !(typeof(u) <: ArrayPartition)
       rate_prototype = similar(u,typeof(oneunit(uBottomEltype)/oneunit(tType)))


### PR DESCRIPTION
When I started debugging the stack overflow error that I get when I replace `diffeq_fd` with `diffeq_rd` in the [DiffEqFlux example](https://github.com/JuliaDiffEq/DiffEqFlux.jl#using-other-differential-equations) (by the way, e.g., using `EM` (with fixed step size `dt = 0.01`) and `SRIW1` with `diffeq_rd` works fine at least in this example), I noticed that solve.jl contains some redundant and unneeded lines and differs from the implementation in OrdinaryDiffEq quite a bit although it shouldn't (it seems at least) - I assume it's just different updates and improvements not being applied to StochasticDiffEq as well. I tried to fix these issues.

I was wondering whether parts of the implementation in OrdinaryDiffEq and StochasticDiffEq could/should be moved to a common package (maybe DiffEqBase but I guess implementations tailored only for OrdinaryDiffEq and StochasticDiffEq might be a bit too specific there?) to avoid such issues in the future; e.g., `handle_dt!` is completely identical, large parts of the argument parsing and checking, type construction are identical or at least similar (by moving specific conditions that are different in both packages to separate functions one could increase this even more, I guess), and I assume that also other parts of the integrator interface are (or should be) implemented in a identical or very similar way.