### PR TITLE
SROCK1 M-dimensional General Noise

### DIFF
--- a/src/caches/SROCK_caches.jl
+++ b/src/caches/SROCK_caches.jl
@@ -5,13 +5,13 @@ mutable struct SROCK1ConstantCache{zType,uEltypeNoUnits} <: StochasticDiffEqCons
   mdeg::Int
   optimal_η::uEltypeNoUnits
 end
-@cache struct SROCK1Cache{uType,rateType} <: StochasticDiffEqMutableCache
+@cache struct SROCK1Cache{uType,rateType,noiseRateType} <: StochasticDiffEqMutableCache
   u::uType
   uprev::uType
   uᵢ₋₁::uType
   uᵢ₋₂::uType
-  gₘ₋₁::rateType
-  gₘ₋₂::rateType
+  gₘ₋₁::noiseRateType
+  gₘ₋₂::noiseRateType
   tmp::uType
   k::rateType
   fsalfirst::rateType
@@ -27,8 +27,8 @@ function alg_cache(alg::SROCK1,prob,u,ΔW,ΔZ,p,rate_prototype,noise_rate_protot
   k = zero(rate_prototype)
   uᵢ₋₁ = zero(u)
   uᵢ₋₂ = zero(u)
-  gₘ₋₁ = zero(rate_prototype)
-  gₘ₋₂ = zero(rate_prototype)
+  gₘ₋₁ = zero(noise_rate_prototype)
+  gₘ₋₂ = zero(noise_rate_prototype)
   tmp  = uᵢ₋₂             # these 3 variables are dummied to use same memory
   fsalfirst = k
   atmp = zero(rate_prototype)

--- a/src/caches/SROCK_caches.jl
+++ b/src/caches/SROCK_caches.jl
@@ -78,7 +78,7 @@ function alg_cache(alg::SROCK2,prob,u,ΔW,ΔZ,p,rate_prototype,noise_rate_protot
   uᵢ₋₂ = zero(u)
   Gₛ = zero(noise_rate_prototype)
   Gₛ₁ = zero(noise_rate_prototype)
-  vec_χ .= false .* vec(ΔW)
+  vec_χ = false .* vec(ΔW)
   tmp  = uᵢ₋₂            # these 2 variables are dummied to use same memory
   fsalfirst = k
   atmp = zero(rate_prototype)

--- a/src/caches/SROCK_caches.jl
+++ b/src/caches/SROCK_caches.jl
@@ -30,8 +30,8 @@ function alg_cache(alg::SROCK1,prob,u,ΔW,ΔZ,p,rate_prototype,noise_rate_protot
   gₘ₋₁ = zero(rate_prototype)
   gₘ₋₂ = zero(rate_prototype)
   tmp  = uᵢ₋₂             # these 3 variables are dummied to use same memory
-  fsalfirst = gₘ₋₁
-  atmp = gₘ₋₂
+  fsalfirst = k
+  atmp = zero(rate_prototype)
   constantcache = SROCK1ConstantCache{uEltypeNoUnits}(u)
   SROCK1Cache(u,uprev,uᵢ₋₁,uᵢ₋₂,gₘ₋₁,gₘ₋₂,tmp,k,fsalfirst,atmp,constantcache)
 end
@@ -78,9 +78,9 @@ function alg_cache(alg::SROCK2,prob,u,ΔW,ΔZ,p,rate_prototype,noise_rate_protot
   uᵢ₋₂ = zero(u)
   Gₛ = zero(noise_rate_prototype)
   Gₛ₁ = zero(noise_rate_prototype)
-  vec_χ = zeros(eltype(ΔW),length(ΔW))
-  tmp  = zero(u)             # these 3 variables are dummied to use same memory
-  fsalfirst = zero(rate_prototype)
+  vec_χ .= false .* vec(ΔW)
+  tmp  = uᵢ₋₂            # these 2 variables are dummied to use same memory
+  fsalfirst = k
   atmp = zero(rate_prototype)
   constantcache = SROCK2ConstantCache{uEltypeNoUnits}(u)
   SROCK2Cache{typeof(u),typeof(k),typeof(noise_rate_prototype),typeof(vec_χ)}(u,uprev,uᵢ,uₓ,uᵢ₋₁,uᵢ₋₂,Gₛ,Gₛ₁,vec_χ,tmp,k,fsalfirst,atmp,constantcache)

--- a/src/perform_step/SROCK_perform_step.jl
+++ b/src/perform_step/SROCK_perform_step.jl
@@ -92,7 +92,6 @@ end
   end
 
   @.. uᵢ₋₂ = uprev
-  integrator.f(k,uprev,p,t)
   Tᵢ₋₂ = one(eltype(u))
   Tᵢ₋₁ = convert(eltype(u),ω₀)
   Tᵢ   = Tᵢ₋₁
@@ -101,6 +100,9 @@ end
   tᵢ₋₂ = t
 
   #stage 1
+  #this take advantage of the fact that cache.k === cache.fsalfirst
+  #and this has already been done i maxeig!  i.e. integrator.f(fsalfirst, uprev, p, t)
+  # integrator.f(k,uprev,p,t)
   @.. uᵢ₋₁ = uprev + (dt*ω₁/ω₀)*k
 
   for i in 2:mdeg
@@ -361,7 +363,9 @@ end
 
   # stage 1
   @.. uᵢ₋₂ = uprev
-  integrator.f(k,uprev,p,t)
+  #this take advantage of the fact that cache.k === cache.fsalfirst
+  #and this has already been done i maxeig!  i.e. integrator.f(fsalfirst, uprev, p, t)
+  # integrator.f(k,uprev,p,t)
   @.. uᵢ₋₁ = uprev + α*dt*μ*k
 
   # stages 2 upto s-2

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,7 +17,6 @@ is_APPVEYOR = ( Sys.iswindows() && haskey(ENV,"APPVEYOR") )
 @time begin
   if group == "All" || group == "Interface"
     @time @testset "First Rand Tests" begin include("first_rand_test.jl") end
-    @time @testset "Linear SDE Tests" begin include("sde/sde_linear_tests.jl") end
     @time @testset "Linear RODE Tests" begin include("rode_linear_tests.jl") end
     @time @testset "Number Type Tests" begin include("sde/sde_numbertype_tests.jl") end
     @time @testset "Complex Number Tests" begin include("complex_tests.jl") end
@@ -33,9 +32,13 @@ is_APPVEYOR = ( Sys.iswindows() && haskey(ENV,"APPVEYOR") )
     @time @testset "Events Tests" begin include("events_test.jl") end
     @time @testset "Cache Tests" begin include("cache_test.jl") end
     @time @testset "No Index Tests" begin include("noindex_tests.jl") end
+    @time @testset "Adaptive Complex Mean Test" begin include("adaptive/sde_complex_adaptive_mean_test.jl") end
+    @time @testset "Utility Tests" begin include("utility_tests.jl") end
+    @time @testset "Non-diagonal SDE Tests" begin include("nondiagonal_tests.jl") end
   end
 
   if group == "All" || group == "Interface2"
+    @time @testset "Linear SDE Tests" begin include("sde/sde_linear_tests.jl") end
     @time @testset "Two-dimensional Linear SDE Tests" begin include("sde/sde_twodimlinear_tests.jl") end
     @time @testset "Element-wise Tolerances Tests" begin include("tolerances_tests.jl") end
     @time @testset "Zero'd Noise Tests" begin include("zerod_noise_test.jl") end
@@ -45,8 +48,6 @@ is_APPVEYOR = ( Sys.iswindows() && haskey(ENV,"APPVEYOR") )
     @time @testset "Multiple Dimension Linear Adaptive Test" begin include("adaptive/sde_twodimlinearadaptive_tests.jl") end
     @time @testset "Autostepsize Test" begin include("adaptive/sde_autostepsize_test.jl") end
     @time @testset "Additive Lorenz Attractor Test" begin include("adaptive/sde_lorenzattractor_tests.jl") end
-    @time @testset "Adaptive Complex Mean Test" begin include("adaptive/sde_complex_adaptive_mean_test.jl") end
-    @time @testset "Utility Tests" begin include("utility_tests.jl") end
   end
 
   if !is_APPVEYOR && (group == "All" || group == "AlgConvergence")
@@ -55,7 +56,6 @@ is_APPVEYOR = ( Sys.iswindows() && haskey(ENV,"APPVEYOR") )
   end
 
   if !is_APPVEYOR && (group == "All" || group == "AlgConvergence2")
-    @time @testset "Non-diagonal SDE Tests" begin include("nondiagonal_tests.jl") end
     @time @testset "Additive SDE Tests" begin include("sde/sde_additive_tests.jl") end
     @time @testset "Split Tests" begin include("split_tests.jl") end
     @time @testset "Stratonovich Convergence Tests" begin include("stratonovich_convergence_tests.jl") end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -31,10 +31,10 @@ is_APPVEYOR = ( Sys.iswindows() && haskey(ENV,"APPVEYOR") )
     @time @testset "Composite Tests" begin include("composite_algorithm_test.jl") end
     @time @testset "Events Tests" begin include("events_test.jl") end
     @time @testset "Cache Tests" begin include("cache_test.jl") end
-    @time @testset "No Index Tests" begin include("noindex_tests.jl") end
     @time @testset "Adaptive Complex Mean Test" begin include("adaptive/sde_complex_adaptive_mean_test.jl") end
     @time @testset "Utility Tests" begin include("utility_tests.jl") end
     @time @testset "Non-diagonal SDE Tests" begin include("nondiagonal_tests.jl") end
+    @time @testset "No Index Tests" begin include("noindex_tests.jl") end
   end
 
   if group == "All" || group == "Interface2"

--- a/test/weak_convergence.jl
+++ b/test/weak_convergence.jl
@@ -24,7 +24,7 @@ sim2 = test_convergence(dts,prob,SROCK1(),numMonte=Int(1e4),
 @test abs(sim2.𝒪est[:weak_final]-1) < 0.3
 @test abs(sim2.𝒪est[:weak_l2]-1) < 0.3
 @test abs(sim2.𝒪est[:weak_l∞]-1) < 0.3
-sim2 = test_convergence(dts,prob,SROCK2(),numMonte=Int(1e4),
+sim2 = test_convergence(dts,prob,SROCK2(),numMonte=Int(1e5),
                         weak_timeseries_errors=true,dense_errors=true)
 @test abs(sim2.𝒪est[:weak_final]-2) < 0.3
 @test abs(sim2.𝒪est[:weak_l2]-2) < 0.3
@@ -86,7 +86,7 @@ sim2 = test_convergence(dts,prob,SROCK1(),numMonte=Int(1e4),
 @test abs(sim2.𝒪est[:weak_final]-1) < 0.3
 @test abs(sim2.𝒪est[:weak_l2]-1) < 0.3
 @test abs(sim2.𝒪est[:weak_l∞]-1) < 0.3
-sim2 = test_convergence(dts,prob,SROCK2(),numMonte=Int(1e4),
+sim2 = test_convergence(dts,prob,SROCK2(),numMonte=Int(1e5),
                         weak_timeseries_errors=true)
 @test abs(sim2.𝒪est[:weak_final]-2) < 0.3
 @test abs(sim2.𝒪est[:weak_l2]-2) < 0.3
@@ -148,7 +148,7 @@ sim2 = test_convergence(dts,prob,SROCK1(),numMonte=Int(1e4),
 @test abs(sim2.𝒪est[:weak_final]-1) < 0.3
 @test abs(sim2.𝒪est[:weak_l2]-1) < 0.3
 @test abs(sim2.𝒪est[:weak_l∞]-1) < 0.3
-sim2 = test_convergence(dts,prob,SROCK2(),numMonte=Int(1e4),
+sim2 = test_convergence(dts,prob,SROCK2(),numMonte=Int(1e5),
                         weak_timeseries_errors=true)
 @test abs(sim2.𝒪est[:weak_final]-2) < 0.3
 @test abs(sim2.𝒪est[:weak_l2]-2) < 0.3


### PR DESCRIPTION
@ChrisRackauckas  
1. `SROCK1` and `SROCK2` memory optimisation and 1 less function call
2. `SROCK1` type stability for `noise_rate_type`
3. `SROCK1` can now handle general noise with order 0.5

#73 
