### PR TITLE
Changes for NLSolver change

### DIFF
--- a/src/StochasticDiffEq.jl
+++ b/src/StochasticDiffEq.jl
@@ -39,13 +39,15 @@ module StochasticDiffEq
 
   using DiffEqBase: check_error!, is_diagonal_noise, @..
 
-  using DiffEqBase: nlsolvefail, isnewton, set_new_W!, get_W, @iipnlsolve, @oopnlsolve, _vec, _reshape
+  using DiffEqBase: nlsolvefail, isnewton, set_new_W!, get_W, iipnlsolve, oopnlsolve, _vec, _reshape, @getiipnlsolvefields
 
   using DiffEqBase: NLSolver
 
   using DiffEqBase: FastConvergence, Convergence, SlowConvergence, VerySlowConvergence, Divergence
 
   import DiffEqBase: calculate_residuals, calculate_residuals!, nlsolve_f, unwrap_cache, islinear
+
+  import DiffEqBase: iip_get_uf, oop_get_uf, build_jac_config
 
 
   const CompiledFloats = Union{Float32,Float64}

--- a/src/caches/implicit_split_step_caches.jl
+++ b/src/caches/implicit_split_step_caches.jl
@@ -23,7 +23,9 @@ end
 function alg_cache(alg::ISSEM,prob,u,ΔW,ΔZ,p,rate_prototype,noise_rate_prototype,
                    uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,f,t,dt,::Type{Val{true}})
   γ, c = alg.theta,zero(t)
-  @iipnlsolve
+  J, W = iip_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
+  nlsolver = iipnlsolve(alg,u,uprev,p,t,dt,f,W,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
+  @getiipnlsolvefields
   gtmp = zero(noise_rate_prototype)
   if is_diagonal_noise(prob)
     gtmp2 = gtmp
@@ -45,10 +47,9 @@ end
 function alg_cache(alg::ISSEM,prob,u,ΔW,ΔZ,p,rate_prototype,noise_rate_prototype,
                    uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,f,t,dt,::Type{Val{false}})
   γ, c = alg.theta,zero(t)
-  @oopnlsolve
-  if !DiffEqBase.has_jac(f) && !isnewton(nlsolver)
-    uf = DiffEqDiffTools.UDerivativeWrapper(f,t,p)
-  end
+  W = oop_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
+  nlsolver = oopnlsolve(alg,u,uprev,p,t,dt,f,W,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
+  uf = nlsolver.uf
   ISSEMConstantCache(uf,nlsolver)
 end
 
@@ -78,7 +79,9 @@ end
 function alg_cache(alg::ISSEulerHeun,prob,u,ΔW,ΔZ,p,rate_prototype,noise_rate_prototype,
                    uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,f,t,dt,::Type{Val{true}})
   γ, c = alg.theta,zero(t)
-  @iipnlsolve
+  J, W = iip_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
+  nlsolver = iipnlsolve(alg,u,uprev,p,t,dt,f,W,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
+  @getiipnlsolvefields
 
   gtmp = zero(noise_rate_prototype)
   gtmp2 = zero(rate_prototype)
@@ -103,9 +106,8 @@ end
 function alg_cache(alg::ISSEulerHeun,prob,u,ΔW,ΔZ,p,rate_prototype,noise_rate_prototype,
                    uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,f,t,dt,::Type{Val{false}})
   γ, c = alg.theta,zero(t)
-  @oopnlsolve
-  if !DiffEqBase.has_jac(f) && !isnewton(nlsolver)
-    uf = DiffEqDiffTools.UDerivativeWrapper(f,t,p)
-  end
+  W = oop_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
+  nlsolver = oopnlsolve(alg,u,uprev,p,t,dt,f,W,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
+  uf = nlsolver.uf
   ISSEulerHeunConstantCache(uf,nlsolver)
 end

--- a/src/caches/kencarp_caches.jl
+++ b/src/caches/kencarp_caches.jl
@@ -56,18 +56,13 @@ function alg_cache(alg::SKenCarp,prob,u,ΔW,ΔZ,p,rate_prototype,noise_rate_prot
   atmp = fill!(similar(u,uEltypeNoUnits),0)
   z₁ = similar(u); z₂ = similar(u)
   z₃ = similar(u); z₄ = z
-  dz = similar(u)
   if typeof(f) <: SplitSDEFunction
     k1 = zero(u); k2 = zero(u)
     k3 = zero(u); k4 = zero(u)
-    uf = DiffEqDiffTools.UJacobianWrapper(f.f1,t,p)
   else
     k1 = nothing; k2 = nothing
     k3 = nothing; k4 = nothing
-    uf = DiffEqDiffTools.UJacobianWrapper(f,t,p)
   end
-  linsolve = alg.linsolve(Val{:init},uf,u)
-  jac_config = build_jac_config(alg,f,uf,du1,uprev,u,tmp,dz)
 
   if typeof(ΔW) <: Union{SArray,Number}
     chi2 = copy(ΔW)

--- a/src/caches/sdirk_caches.jl
+++ b/src/caches/sdirk_caches.jl
@@ -30,7 +30,9 @@ function alg_cache(alg::ImplicitEM,prob,u,ΔW,ΔZ,p,rate_prototype,noise_rate_pr
   end
 
   γ, c = alg.theta,zero(t)
-  @iipnlsolve
+  J, W = iip_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
+  nlsolver = iipnlsolve(alg,u,uprev,p,t,dt,f,W,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
+  @getiipnlsolvefields
   ImplicitEMCache(u,uprev,du1,fsalfirst,k,z,dz,tmp,gtmp,gtmp2,J,W,jac_config,linsolve,uf,
                   dW_cache,nlsolver)
 end
@@ -43,10 +45,9 @@ end
 function alg_cache(alg::ImplicitEM,prob,u,ΔW,ΔZ,p,rate_prototype,noise_rate_prototype,
                    uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,f,t,dt,::Type{Val{false}})
   γ, c = alg.theta,zero(t)
-  @oopnlsolve
-  if !DiffEqBase.has_jac(f) && !isnewton(nlsolver)
-    uf = DiffEqDiffTools.UDerivativeWrapper(f,t,p)
-  end
+  W = oop_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
+  nlsolver = oopnlsolve(alg,u,uprev,p,t,dt,f,W,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
+  uf = nlsolver.uf
   ImplicitEMConstantCache(uf,nlsolver)
 end
 
@@ -88,7 +89,9 @@ function alg_cache(alg::ImplicitEulerHeun,prob,u,ΔW,ΔZ,p,rate_prototype,noise_
   end
 
   γ, c = alg.theta,zero(t)
-  @iipnlsolve
+  J, W = iip_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
+  nlsolver = iipnlsolve(alg,u,uprev,p,t,dt,f,W,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
+  @getiipnlsolvefields
   ImplicitEulerHeunCache(u,uprev,du1,fsalfirst,k,z,dz,tmp,gtmp,gtmp2,gtmp3,
                          J,W,jac_config,linsolve,uf,nlsolver,dW_cache)
 end
@@ -101,10 +104,9 @@ end
 function alg_cache(alg::ImplicitEulerHeun,prob,u,ΔW,ΔZ,p,rate_prototype,noise_rate_prototype,
                    uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,f,t,dt,::Type{Val{false}})
   γ, c = alg.theta,zero(t)
-  @oopnlsolve
-  if !DiffEqBase.has_jac(f) && !isnewton(nlsolver)
-    uf = DiffEqDiffTools.UDerivativeWrapper(f,t,p)
-  end
+  W = oop_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
+  nlsolver = oopnlsolve(alg,u,uprev,p,t,dt,f,W,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
+  uf = nlsolver.uf
   ImplicitEulerHeunConstantCache(uf,nlsolver)
 end
 
@@ -135,7 +137,9 @@ function alg_cache(alg::ImplicitRKMil,prob,u,ΔW,ΔZ,p,rate_prototype,noise_rate
   gtmp3 = zero(rate_prototype)
 
   γ, c = alg.theta,zero(t)
-  @iipnlsolve
+  J, W = iip_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
+  nlsolver = iipnlsolve(alg,u,uprev,p,t,dt,f,W,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
+  @getiipnlsolvefields
   ImplicitRKMilCache(u,uprev,du1,fsalfirst,k,z,dz,tmp,gtmp,gtmp2,gtmp3,
                    J,W,jac_config,linsolve,uf,nlsolver)
 end
@@ -148,9 +152,8 @@ end
 function alg_cache(alg::ImplicitRKMil,prob,u,ΔW,ΔZ,p,rate_prototype,noise_rate_prototype,
                    uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,f,t,dt,::Type{Val{false}})
   γ, c = alg.theta,zero(t)
-  @oopnlsolve
-  if !DiffEqBase.has_jac(f) && !isnewton(nlsolver)
-    uf = DiffEqDiffTools.UDerivativeWrapper(f,t,p)
-  end
+  W = oop_generate_W(alg,u,uprev,p,t,dt,f,uEltypeNoUnits)
+  nlsolver = oopnlsolve(alg,u,uprev,p,t,dt,f,W,rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,γ,c)
+  uf = nlsolver.uf
   ImplicitRKMilConstantCache(uf,nlsolver)
 end

--- a/src/derivative_utils.jl
+++ b/src/derivative_utils.jl
@@ -398,3 +398,6 @@ function update_W!(nlsolver::NLSolver, integrator, cache::StochasticDiffEqConsta
   end
   nothing
 end
+
+iip_get_uf(alg::StochasticDiffEqAlgorithm,nf,t,p) = DiffEqDiffTools.UJacobianWrapper(nf,t,p)
+oop_get_uf(alg::StochasticDiffEqAlgorithm,nf,t,p) = DiffEqDiffTools.UDerivativeWrapper(nf,t,p)

--- a/src/derivative_wrappers.jl
+++ b/src/derivative_wrappers.jl
@@ -50,7 +50,7 @@ function jacobian!(J::AbstractMatrix{<:Number}, f, x::AbstractArray{<:Number}, f
     nothing
 end
 
-function build_jac_config(alg,f,uf,du1,uprev,u,tmp,du2)
+function DiffEqBase.build_jac_config(alg::StochasticDiffEqAlgorithm,f,uf,du1,uprev,u,tmp,du2)
   if !has_jac(f)
     if alg_autodiff(alg)
       jac_config = ForwardDiff.JacobianConfig(uf,du1,uprev,ForwardDiff.Chunk{determine_chunksize(u,alg)}())


### PR DESCRIPTION
Ref: JuliaDiffEq/DiffEqBase.jl#250

Let the tests pass first. I have some doubt too - Do SKenCarp need two copies of `linsolve` or `dz` or `jac_config`? Currently we are making two copies of these variables. 