### PR TITLE
manual AoS to SoA in initdt

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -25,7 +25,7 @@ SparseDiffTools = "47a9eef4-7e08-11e9-0b38-333d64bd3804"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
-ArrayInterface = "1.1, 2.0"
+ArrayInterface = "2.4"
 DataStructures = "0.17"
 DiffEqBase = "6.11"
 DiffEqNoiseProcess = "3.3.1"

--- a/src/initdt.jl
+++ b/src/initdt.jl
@@ -2,7 +2,7 @@ function sde_determine_initdt(u0::uType,t::tType,tdir,dtmax,abstol,reltol,intern
   f = prob.f
   g = prob.g
   p = prob.p
-  d₀ = internalnorm(u0./(abstol.+internalnorm.(u0,t).*reltol),t)
+  d₀ = internalnorm(ArrayInterface.aos_to_soa(u0)./(abstol.+internalnorm.(u0,t).*reltol),t)
   if !isinplace(prob)
     f₀ = f(u0,p,t)
     if integrator.opts.verbose && any(x->any(isnan,x),f₀)


### PR DESCRIPTION
It's a tricky one, but since internalnorm will return a concretely-typed value, the denominator can become a SoA through normal broadcasts. By changing the denominator, it makes the next internalnorm easier and fixes potential dispatching issues.