### PR TITLE
non-allocating two-point random variable

### DIFF
--- a/src/StochasticDiffEq.jl
+++ b/src/StochasticDiffEq.jl
@@ -107,8 +107,9 @@ module StochasticDiffEq
   include("iterated_integrals.jl")
   include("SROCK_utils.jl")
   include("composite_algs.jl")
+  include("weak_utils.jl")
 
-   export StochasticDiffEqAlgorithm, StochasticDiffEqAdaptiveAlgorithm,
+  export StochasticDiffEqAlgorithm, StochasticDiffEqAdaptiveAlgorithm,
           StochasticCompositeAlgorithm
 
   export EM, LambaEM, PCEuler, RKMil, SRA, SRI, SRIW1,

--- a/src/caches/basic_method_caches.jl
+++ b/src/caches/basic_method_caches.jl
@@ -69,9 +69,10 @@ function alg_cache(alg::RandomEM,prob,u,ΔW,ΔZ,p,rate_prototype,noise_rate_prot
 end
 
 struct SimplifiedEMConstantCache <: StochasticDiffEqConstantCache end
-@cache struct SimplifiedEMCache{uType,rateType,rateNoiseType} <: StochasticDiffEqMutableCache
+@cache struct SimplifiedEMCache{randType,uType,rateType,rateNoiseType} <: StochasticDiffEqMutableCache
   u::uType
   uprev::uType
+  _dW::randType
   rtmp1::rateType
   rtmp2::rateNoiseType
 end
@@ -79,9 +80,15 @@ end
 alg_cache(alg::SimplifiedEM,prob,u,ΔW,ΔZ,p,rate_prototype,noise_rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,f,t,dt,::Type{Val{false}}) = SimplifiedEMConstantCache()
 
 function alg_cache(alg::SimplifiedEM,prob,u,ΔW,ΔZ,p,rate_prototype,noise_rate_prototype,uEltypeNoUnits,uBottomEltypeNoUnits,tTypeNoUnits,uprev,f,t,dt,::Type{Val{true}})
+  if typeof(ΔW) <: Union{SArray,Number}
+    _dW = copy(ΔW)
+  else
+    _dW = zero(ΔW)
+  end
+
   rtmp1 = zero(rate_prototype)
   rtmp2 = zero(noise_rate_prototype)
-  SimplifiedEMCache(u,uprev,rtmp1,rtmp2)
+  SimplifiedEMCache(u,uprev,_dW, rtmp1,rtmp2)
 end
 
 

--- a/src/weak_utils.jl
+++ b/src/weak_utils.jl
@@ -1,0 +1,7 @@
+@muladd function calc_twopoint_random!(_dW, integrator, dW)
+    @.. _dW = ifelse(sign(dW) > 0.0, integrator.sqdt, -integrator.sqdt)
+end
+
+@muladd function calc_twopoint_random(integrator, dW)
+  return sign(dW) > 0.0 ? integrator.sqdt : -integrator.sqdt
+end


### PR DESCRIPTION
I separated the generation of the random variable to a new file weak_utils.jl that contains a in-place and out-of-place version. I had the feeling that the ternary operator performs (slightly) better than elseif. 