### PR TITLE
Allow separate jac_prototype and sparsity

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -27,7 +27,7 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 [compat]
 ArrayInterface = "2.4"
 DataStructures = "0.17"
-DiffEqBase = "6.11"
+DiffEqBase = "6.19"
 DiffEqNoiseProcess = "3.3.1"
 FillArrays = "0.6, 0.7, 0.8"
 FiniteDiff = "2"

--- a/src/derivative_wrappers.jl
+++ b/src/derivative_wrappers.jl
@@ -24,15 +24,15 @@ jacobian_autodiff(f,x,_,_)=ForwardDiff.derivative(f,x)
 jacobian_autodiff(f,x::AbstractArray,_,hascolorvec::Val{false})=ForwardDiff.jacobian(f,x)
 function jacobian_autodiff(f,x::AbstractArray,integrator,hascolorvec::Val{true})
   colorvec=integrator.f.colorvec
-  jac=integrator.f.jac_prototype
-  J=jac isa SparseMatrixCSC ? similar(jac) : fill(0.,size(jac))
-  forwarddiff_color_jacobian!(J,f,x,colorvec=colorvec,sparsity=jac)
-  J
+  jac_prototype=integrator.f.jac_prototype
+  sparsity=integrator.f.sparsity
+  forwarddiff_color_jacobian(f,x,colorvec=colorvec,sparsity=sparsity,jac_prototype=jac_prototype)
 end
 jacobian_finitediff(f,x,difftype,_,_)=FiniteDiff.finite_difference_derivative(f, x, difftype, eltype(x))
 jacobian_finitediff(f,x::AbstractArray,difftype,_,hascolorvec::Val{false})=FiniteDiff.finite_difference_jacobian(f, x, difftype, eltype(x))
 jacobian_finitediff(f,x::AbstractArray,difftype,integrator,hascolorvec::Val{true})=
-  FiniteDiff.finite_difference_jacobian(f, x, difftype, eltype(x), colorvec=integrator.f.colorvec,sparsity=integrator.f.jac_prototype)
+FiniteDiff.finite_difference_jacobian(f, x, difftype, eltype(x), colorvec=integrator.f.colorvec,
+                                      sparsity=integrator.f.sparsity, jac_prototype=jac_prototype)
 
 function jacobian(f, x,
                   integrator::DiffEqBase.DEIntegrator)
@@ -59,7 +59,7 @@ function jacobian!(J::AbstractMatrix{<:Number}, f, x::AbstractArray{<:Number}, f
 end
 
 jac_cache_autodiff(alg,f,uf,du1,uprev,u,hascolorvec::Val{false})=ForwardDiff.JacobianConfig(uf,du1,uprev,ForwardDiff.Chunk{determine_chunksize(u,alg)}())
-jac_cache_autodiff(alg,f,uf,du1,uprev,u,hascolorvec::Val{true})=ForwardColorJacCache(uf,uprev,colorvec=f.colorvec,sparsity=f.jac_prototype)
+jac_cache_autodiff(alg,f,uf,du1,uprev,u,hascolorvec::Val{true})=ForwardColorJacCache(uf,uprev,colorvec=f.colorvec,sparsity=f.sparsity)
 
 function DiffEqBase.build_jac_config(alg::StochasticDiffEqAlgorithm,f,uf,du1,uprev,u,tmp,du2)
   if !has_jac(f)
@@ -68,9 +68,9 @@ function DiffEqBase.build_jac_config(alg::StochasticDiffEqAlgorithm,f,uf,du1,upr
     else
       colorvec= f.colorvec isa Nothing ? Base.OneTo(length(u)) : f.colorvec
       if alg.diff_type != Val{:complex}
-        jac_config = FiniteDiff.JacobianCache(tmp,du1,du2,alg.diff_type,colorvec=colorvec,sparsity=f.jac_prototype)
+        jac_config = FiniteDiff.JacobianCache(tmp,du1,du2,alg.diff_type,colorvec=colorvec,sparsity=f.sparsity)
       else
-        jac_config = FiniteDiff.JacobianCache(Complex{eltype(tmp)}.(tmp),Complex{eltype(du1)}.(du1),nothing,alg.diff_type,colorvec=colorvec,sparsity=f.jac_prototype)
+        jac_config = FiniteDiff.JacobianCache(Complex{eltype(tmp)}.(tmp),Complex{eltype(du1)}.(du1),nothing,alg.diff_type,colorvec=colorvec,sparsity=f.sparsity)
       end
     end
   else

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,6 +14,7 @@ const is_APPVEYOR = Sys.iswindows() && haskey(ENV,"APPVEYOR")
     @time @safetestset "Static Array Tests" begin include("static_array_tests.jl") end
     @time @safetestset "Noise Type Tests" begin include("noise_type_test.jl") end
     @time @safetestset "Mass matrix tests" begin include("mass_matrix_tests.jl") end
+    #@time @safetestset "Sparse Jacobian tests" begin include("sparsediff_tests.jl") end
     @time @safetestset "Outofplace Arrays Tests" begin include("outofplace_arrays.jl") end
     @time @safetestset "tdir Tests" begin include("tdir_tests.jl") end
     @time @safetestset "tstops Tests" begin include("tstops_tests.jl") end


### PR DESCRIPTION
Make it compatible with https://github.com/JuliaDiffEq/DiffEqBase.jl/pull/449.

I really don't know this code, so I couldn't judge whether `jac_prototype` could/should be replaced with `sparsity`.  See https://github.com/JuliaDiffEq/StochasticDiffEq.jl/search?q=jac_prototype&type=Code.

Also note that the only [file](https://github.com/JuliaDiffEq/StochasticDiffEq.jl/blob/03d695e07aeffeb525b2cc84892e94f0292bbee2/test/sparsediff_tests.jl) which kinda tests this is not run through the test suite and does indeed not pass (at least with this PR).