### PR TITLE
Fix markdown syntax in docstrings

### DIFF
--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -1001,7 +1001,7 @@ parameters θ and η.
     Milan J. Math. 77, 205–244 (2009). https://doi.org/10.1007/s00032-009-0100-0
   - Originally introduced in PR #88 (commit 42e2510) by Tatsuhiro Onodera (2018)
 
-!!! warning################################################################################
+!!! warning
 
     The derivative `ggprime` must be computed analytically for correctness.# Rossler
     The original paper contains a typo in the definition of ggprime - this


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

Extraneous hashes removed
