### PR TITLE
Fix undefined variable references and add missing method dispatches

### DIFF
--- a/src/alg_utils.jl
+++ b/src/alg_utils.jl
@@ -447,6 +447,7 @@ end
 end
 
 alg_mass_matrix_compatible(alg::StochasticDiffEqAlgorithm) = false
+alg_mass_matrix_compatible(alg::StochasticDiffEqRODEAlgorithm) = false
 alg_can_repeat_jac(alg::StochasticDiffEqAlgorithm) = true
 
 function alg_mass_matrix_compatible(alg::Union{
@@ -522,4 +523,5 @@ function OrdinaryDiffEqCore.unwrap_alg(integrator::SDEIntegrator, is_stiff)
 end
 
 alg_control_rate(::StochasticDiffEqAlgorithm) = false
+alg_control_rate(::StochasticDiffEqRODEAlgorithm) = false
 alg_control_rate(::TauLeaping) = true

--- a/src/integrators/integrator_interface.jl
+++ b/src/integrators/integrator_interface.jl
@@ -201,7 +201,7 @@ function resize_non_user_cache!(integrator::SDEIntegrator, cache, i)
 end
 
 function deleteat!(integrator::SDEIntegrator, idxs)
-    deleteat_non_user_cache!(integrator, cache, idxs)
+    deleteat_non_user_cache!(integrator, integrator.cache, idxs)
     for c in full_cache(integrator)
         deleteat!(c, idxs)
     end
@@ -211,7 +211,7 @@ function deleteat!(integrator::SDEIntegrator, idxs)
 end
 
 function addat!(integrator::SDEIntegrator, idxs)
-    addat_non_user_cache!(integrator, cache, idxs)
+    addat_non_user_cache!(integrator, integrator.cache, idxs)
     for c in full_cache(integrator)
         addat!(c, idxs)
     end

--- a/src/integrators/integrator_utils.jl
+++ b/src/integrators/integrator_utils.jl
@@ -305,9 +305,9 @@ end
     if integrator.P !== nothing && integrator.opts.adaptive
         if integrator.cache isa StochasticDiffEqMutableCache
             oldrate = integrator.P.cache.currate
-            P.cache.rate(oldrate, u, p, t)
+            integrator.P.cache.rate(oldrate, integrator.u, integrator.p, integrator.t)
         else
-            integrator.P.cache.currate = P.cache.rate(u, p, t)
+            integrator.P.cache.currate = integrator.P.cache.rate(integrator.u, integrator.p, integrator.t)
         end
     end
 end


### PR DESCRIPTION
## Summary

This PR addresses several bugs and missing method dispatches found during JET.jl static analysis:

### Bug fixes
- **`handle_callback_modifiers!` in `integrator_utils.jl`**: Fixed undefined variable references where `P`, `u`, `p`, and `t` were used instead of `integrator.P`, `integrator.u`, `integrator.p`, and `integrator.t`
- **`deleteat!` and `addat!` in `integrator_interface.jl`**: Fixed undefined variable reference where `cache` was used instead of `integrator.cache`

### Missing method dispatches
- Added `alg_mass_matrix_compatible(::StochasticDiffEqRODEAlgorithm) = false` - this method was only defined for `StochasticDiffEqAlgorithm` but called with RODE algorithms in `solve.jl`
- Added `alg_control_rate(::StochasticDiffEqRODEAlgorithm) = false` - same situation, needed for RODE algorithm dispatch

### JET Analysis Results
- Before: 187 potential errors reported
- After: 180 potential errors reported

The remaining errors are in other areas of the codebase (mostly related to `aliases` variable flow in `solve.jl` and some undefined local variables in `perform_step` functions) that would require more invasive changes to address.

## Test plan
- [x] Package loads correctly
- [x] `@inferred solve(prob, EM(), dt=dt)` passes
- [x] `test/inference_test.jl` passes
- [x] `test/static_array_tests.jl` passes  
- [x] `test/default_solver_test.jl` passes
- [x] `test/rode_linear_tests.jl` passes

cc @ChrisRackauckas

🤖 Generated with [Claude Code](https://claude.com/claude-code)