### PR TITLE
Add Allocations test group to CI with nopre configuration

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -20,10 +20,14 @@ jobs:
           - AlgConvergence2
           - AlgConvergence3
           - WeakConvergence1
+          - Allocations
         version:
           - 'lts'
           - '1'
           - 'pre'
+        exclude:
+          - group: Allocations
+            version: 'pre'
     steps:
       - uses: actions/checkout@v6
       - uses: julia-actions/setup-julia@v2


### PR DESCRIPTION
## Summary

- Adds the Allocations test group from PR #656 to the CI matrix
- Excludes the Allocations group from running on pre-release Julia versions (`pre`) to avoid allocation counting inconsistencies on unstable builds

## Test plan

- [x] CI.yml syntax is valid
- [ ] CI runs Allocations tests on `lts` and `1` versions
- [ ] CI skips Allocations tests on `pre` version

🤖 Generated with [Claude Code](https://claude.com/claude-code)