### PR TITLE
Fix nlsolver.c time coefficient in implicit SDE methods

### DIFF
--- a/src/perform_step/implicit_split_step.jl
+++ b/src/perform_step/implicit_split_step.jl
@@ -25,7 +25,9 @@
     end
     nlsolver.z = z
 
-    nlsolver.c = a
+    # nlsolver.c should be the Butcher tableau coefficient (time fraction), not coefficient*dt
+    # OrdinaryDiffEqNonlinearSolve computes tstep = t + c * dt, so c should be in [0,1]
+    nlsolver.c = alg.symplectic ? one(t) / 2 : theta
     if alg.symplectic
         # u = uprev + z then  u = (uprev+u)/2 = (uprev+uprev+z)/2 = uprev + z/2
         #u = uprev + z/2
@@ -219,7 +221,9 @@ end
         #@.. u = uprev + dt*(1-theta)*tmp + theta*z
         @.. tmp = uprev + dt * (1 - theta) * tmp
     end
-    nlsolver.c = a
+    # nlsolver.c should be the Butcher tableau coefficient (time fraction), not coefficient*dt
+    # OrdinaryDiffEqNonlinearSolve computes tstep = t + c * dt, so c should be in [0,1]
+    nlsolver.c = alg.symplectic ? one(t) / 2 : theta
     z = OrdinaryDiffEqNonlinearSolve.nlsolve!(nlsolver, integrator, cache, repeat_step)
     OrdinaryDiffEqNonlinearSolve.nlsolvefail(nlsolver) && return
 

--- a/src/perform_step/sdirk.jl
+++ b/src/perform_step/sdirk.jl
@@ -53,7 +53,9 @@
         z = dt * ftmp # linear extrapolation
     end
     nlsolver.z = z
-    nlsolver.c = a
+    # nlsolver.c should be the Butcher tableau coefficient (time fraction), not coefficient*dt
+    # OrdinaryDiffEqNonlinearSolve computes tstep = t + c * dt, so c should be in [0,1]
+    nlsolver.c = alg.symplectic ? one(t) / 2 : theta
 
     if alg.symplectic
         # u = uprev + z then  u = (uprev+u)/2 = (uprev+uprev+z)/2 = uprev + z/2
@@ -194,7 +196,9 @@ end
         @.. z = dt * tmp # linear extrapolation
     end
 
-    nlsolver.c = a
+    # nlsolver.c should be the Butcher tableau coefficient (time fraction), not coefficient*dt
+    # OrdinaryDiffEqNonlinearSolve computes tstep = t + c * dt, so c should be in [0,1]
+    nlsolver.c = alg.symplectic ? one(t) / 2 : theta
     if alg.symplectic
         #@.. u = uprev + z/2 + gtmp2/2
         if P !== nothing

--- a/test/implicit_time_parameter_test.jl
+++ b/test/implicit_time_parameter_test.jl
@@ -1,0 +1,137 @@
+using StochasticDiffEq, Test
+
+@testset "ImplicitEM Newton solver time coefficient" begin
+    # This test verifies that implicit SDE solvers evaluate the drift function
+    # at the correct time during Newton iterations. The nlsolver.c coefficient
+    # should be the Butcher tableau coefficient (in [0,1]), not coefficient*dt.
+    #
+    # Bug: nlsolver.c was set to theta*dt instead of theta, causing the Newton
+    # method to evaluate f at t + theta*dt*dt instead of t + theta*dt.
+    # This caused extrapolation errors when using time-dependent parameters
+    # with interpolations that end exactly at tspan[2].
+    #
+    # Reference: https://github.com/SciML/ModelingToolkit.jl/issues/4143
+
+    @testset "Verify Newton evaluates at correct time" begin
+        # Test: use a function that records the time it's called at
+        # and verify all times are within the expected range [0, tend]
+
+        tend = 1.0
+        recorded_times = Float64[]
+
+        function f_recording!(du, u, p, t)
+            push!(recorded_times, t)
+            du[1] = -u[1]
+        end
+
+        function g!(du, u, p, t)
+            du[1] = 0.1 * u[1]
+        end
+
+        u0 = [1.0]
+        tspan = (0.0, tend)
+        prob = SDEProblem(f_recording!, g!, u0, tspan)
+
+        # Test ImplicitEM
+        empty!(recorded_times)
+        solve(prob, ImplicitEM(); dt = 0.1, adaptive = false)
+
+        # All recorded times should be within [0, tend]
+        # With the bug (c = theta*dt), times would be at t + theta*dt*dt
+        # which is wrong but usually smaller than expected
+        # With the fix (c = theta), times should be at t + theta*dt
+        @test all(0.0 .<= recorded_times .<= tend + 10 * eps(tend))
+        @test maximum(recorded_times) <= tend + 10 * eps(tend)
+
+        # The maximum recorded time should be close to tend
+        # With the bug, the Newton method would evaluate at t + dt*dt instead of t + dt
+        # So for a step from t=0.9 to t=1.0, the bug gives 0.9 + 0.01 = 0.91,
+        # while correct gives 0.9 + 0.1 = 1.0
+        @test maximum(recorded_times) >= tend - 0.15  # Should reach close to tend
+
+        # Test ImplicitEulerHeun
+        empty!(recorded_times)
+        solve(prob, ImplicitEulerHeun(); dt = 0.1, adaptive = false)
+        @test all(0.0 .<= recorded_times .<= tend + 10 * eps(tend))
+
+        # Test ImplicitRKMil
+        empty!(recorded_times)
+        solve(prob, ImplicitRKMil(); dt = 0.1, adaptive = false)
+        @test all(0.0 .<= recorded_times .<= tend + 10 * eps(tend))
+    end
+
+    @testset "Test with adaptive stepping" begin
+        # Test that adaptive stepping also works correctly
+        recorded_times = Float64[]
+
+        function f_recording!(du, u, p, t)
+            push!(recorded_times, t)
+            du[1] = -u[1]
+        end
+
+        function g!(du, u, p, t)
+            du[1] = 0.1 * u[1]
+        end
+
+        u0 = [1.0]
+        tspan = (0.0, 1.0)
+        prob = SDEProblem(f_recording!, g!, u0, tspan)
+
+        empty!(recorded_times)
+        solve(prob, ImplicitEM())
+
+        # All recorded times should be within [0, tend]
+        @test all(0.0 .<= recorded_times .<= 1.0 + 10 * eps(1.0))
+    end
+
+    @testset "Test ISSEM methods" begin
+        # Test split-step methods as well
+        recorded_times = Float64[]
+
+        function f_recording!(du, u, p, t)
+            push!(recorded_times, t)
+            du[1] = -u[1]
+        end
+
+        function g!(du, u, p, t)
+            du[1] = 0.1 * u[1]
+        end
+
+        u0 = [1.0]
+        tspan = (0.0, 1.0)
+        prob = SDEProblem(f_recording!, g!, u0, tspan)
+
+        # Test ISSEM
+        empty!(recorded_times)
+        solve(prob, ISSEM(); dt = 0.1, adaptive = false)
+        @test all(0.0 .<= recorded_times .<= 1.0 + 10 * eps(1.0))
+
+        # Test ISSEulerHeun
+        empty!(recorded_times)
+        solve(prob, ISSEulerHeun(); dt = 0.1, adaptive = false)
+        @test all(0.0 .<= recorded_times .<= 1.0 + 10 * eps(1.0))
+    end
+
+    @testset "Out-of-place methods" begin
+        # Test out-of-place versions
+        recorded_times = Float64[]
+
+        function f_recording(u, p, t)
+            push!(recorded_times, t)
+            return -u
+        end
+
+        function g(u, p, t)
+            return 0.1 * u
+        end
+
+        u0 = [1.0]
+        tspan = (0.0, 1.0)
+        prob = SDEProblem(f_recording, g, u0, tspan)
+
+        # Test ImplicitEM out-of-place
+        empty!(recorded_times)
+        solve(prob, ImplicitEM(); dt = 0.1, adaptive = false)
+        @test all(0.0 .<= recorded_times .<= 1.0 + 10 * eps(1.0))
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -112,6 +112,9 @@ const is_APPVEYOR = Sys.iswindows() && haskey(ENV, "APPVEYOR")
         @time @safetestset "Utility Tests" begin
             include("utility_tests.jl")
         end
+        @time @safetestset "Implicit Time Parameter Tests" begin
+            include("implicit_time_parameter_test.jl")
+        end
         @time @safetestset "Non-diagonal SDE Tests" begin
             include("nondiagonal_tests.jl")
         end


### PR DESCRIPTION
## Summary

- Fix `nlsolver.c` assignment in `sdirk.jl` and `implicit_split_step.jl` to use the Butcher tableau coefficient instead of `coefficient * dt`
- Add test to verify Newton solver evaluates at correct times

## Problem

The `nlsolver.c` coefficient should be the Butcher tableau coefficient (a value in [0,1] representing the time fraction), not `coefficient * dt`.

`OrdinaryDiffEqNonlinearSolve` computes `tstep = t + c * dt`, so setting `c = theta * dt` (as was done) would give:
- **Bug**: `tstep = t + theta * dt * dt = t + theta * dt²`
- **Correct**: `tstep = t + theta * dt`

This caused incorrect time evaluation in the Newton method, which could lead to extrapolation errors when using time-dependent parameters with interpolations that end exactly at `tspan[2]`.

## Root Cause

In commit 5f64ab0 (May 2020), when StochasticDiffEq started using OrdinaryDiffEq's nlsolve infrastructure, the `nlsolver.c = a` assignment was copied without accounting for the fact that `c` in OrdinaryDiffEq is a Butcher tableau coefficient (like 1 for implicit Euler), not `coefficient * dt`.

For reference, OrdinaryDiffEq's SDIRK methods set `nlsolver.c = 1` for implicit Euler, while StochasticDiffEq was setting `nlsolver.c = theta * dt`.

## Fix

Changed:
```julia
nlsolver.c = a  # where a = theta * dt
```

To:
```julia
nlsolver.c = alg.symplectic ? one(t) / 2 : theta
```

## Test plan

- [x] Added test that records evaluation times and verifies they're within expected bounds
- [x] Test covers ImplicitEM, ImplicitEulerHeun, ImplicitRKMil, ISSEM, ISSEulerHeun
- [x] Test covers both in-place and out-of-place methods
- [x] Test passes locally

Fixes: https://github.com/SciML/ModelingToolkit.jl/issues/4143

🤖 Generated with [Claude Code](https://claude.ai/code)