### PR TITLE
Support AbstractSDDEIntegrator in change_t_via_interpolation!

### DIFF
--- a/src/integrators/integrator_interface.jl
+++ b/src/integrators/integrator_interface.jl
@@ -1,5 +1,6 @@
 @inline function DiffEqBase.change_t_via_interpolation!(
-        integrator::SDEIntegrator, t, modify_save_endpoint::Type{Val{T}} = Val{false},
+        integrator::Union{SDEIntegrator, AbstractSDDEIntegrator}, t,
+        modify_save_endpoint::Type{Val{T}} = Val{false},
         reinitialize_alg = nothing
     ) where {T}
     # Can get rid of an allocation here with a function


### PR DESCRIPTION
## Summary

- Expand the type signature for `change_t_via_interpolation!` to accept both `SDEIntegrator` and `AbstractSDDEIntegrator`

This allows StochasticDelayDiffEq to use the existing implementation for its `SDDEIntegrator` type, fixing a regression where callbacks would fail with:
```
change_t_via_interpolation!: method has not been implemented for the integrator
```

## Test plan

- [x] Tested with StochasticDelayDiffEq locally - all tests pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)