### PR TITLE
Rename ODEVerbosity to DEVerbosity

### DIFF
--- a/src/StochasticDiffEq.jl
+++ b/src/StochasticDiffEq.jl
@@ -40,7 +40,7 @@ using SciMLLogging: AbstractVerbositySpecifier, AbstractVerbosityPreset,
     AbstractMessageLevel, None, Minimal, Standard, Detailed, All,
     Silent, DebugLevel, InfoLevel, WarnLevel, ErrorLevel, @SciMLMessage
 
-using OrdinaryDiffEqCore: ODEVerbosity
+using OrdinaryDiffEqCore: DEVerbosity
 
 using LinearAlgebra, Random
 

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -620,15 +620,15 @@ function DiffEqBase.__init(
 
     dW, dZ = isnothing(W) ? (nothing, nothing) : (W.dW, W.dZ)
 
-    # Convert verbose argument to ODEVerbosity
+    # Convert verbose argument to DEVerbosity
     verbose_internal = if verbose isa Bool
-        verbose ? ODEVerbosity(Standard()) : ODEVerbosity(None())
+        verbose ? DEVerbosity(Standard()) : DEVerbosity(None())
     elseif verbose isa AbstractVerbosityPreset
-        ODEVerbosity(verbose)
-    elseif verbose isa ODEVerbosity
+        DEVerbosity(verbose)
+    elseif verbose isa DEVerbosity
         verbose
     else
-        throw(ArgumentError("verbose must be a Bool, AbstractVerbosityPreset, or ODEVerbosity"))
+        throw(ArgumentError("verbose must be a Bool, AbstractVerbosityPreset, or DEVerbosity"))
     end
 
     cache = alg_cache(


### PR DESCRIPTION
## Summary
- Rename `ODEVerbosity` to `DEVerbosity` to match the updated OrdinaryDiffEqCore API

## Changes
- Updated import in `src/StochasticDiffEq.jl`
- Updated all usages in `src/solve.jl`

🤖 Generated with [Claude Code](https://claude.com/claude-code)