### PR TITLE
Fix saveat interpolation with ContinuousCallback

### DIFF
--- a/src/integrators/integrator_interface.jl
+++ b/src/integrators/integrator_interface.jl
@@ -14,11 +14,12 @@
         else
             integrator.u = integrator(t)
         end
-        integrator.dtnew = integrator.t - t
         reject_step!(integrator, t - integrator.tprev) #this only changes dt and noise, so no interpolation problems
-        integrator.dt = integrator.dtnew
-        integrator.sqdt = sqrt(abs(integrator.dt))
         integrator.t = t
+        # dt should be the step from tprev to t (for correct interpolation in savevalues!)
+        # This matches the behavior in OrdinaryDiffEq
+        integrator.dt = integrator.t - integrator.tprev
+        integrator.sqdt = sqrt(abs(integrator.dt))
 
         # reeval_internals_due_to_modification!(integrator) # Not necessary for linear interp
         if T


### PR DESCRIPTION
## Summary
- Fixes incorrect saveat interpolation when using ContinuousCallback
- Aligns behavior with OrdinaryDiffEq's `change_t_via_interpolation!`
- Adds regression test for the fix

## Problem
When a `ContinuousCallback` fires, `change_t_via_interpolation!` was setting `integrator.dt` to `old_t - cb_time` (the remaining step after the callback). This caused `savevalues!` to compute incorrect interpolation coefficients (Θ values) for saveat points between `tprev` and the callback time.

The result was that saveat values were wildly incorrect after callbacks, as demonstrated in https://github.com/SciML/DifferentialEquations.jl/issues/1121 - users saw phase jumps of 28+ in Wiener process components instead of the expected ~0.08.

## Fix
Set `integrator.dt = integrator.t - integrator.tprev` after `change_t_via_interpolation!`, matching OrdinaryDiffEq's behavior:

**Before (StochasticDiffEq):**
```julia
integrator.dtnew = integrator.t - t  # old_t - cb_time
integrator.dt = integrator.dtnew     # WRONG for interpolation!
integrator.t = t
```

**After (matching OrdinaryDiffEq):**
```julia
integrator.t = t
integrator.dt = integrator.t - integrator.tprev  # cb_time - tprev (CORRECT)
```

## Test plan
- [x] New test verifies saveat values match dense solution to machine precision
- [x] Test verifies no large phase jumps occur (the original bug symptom)
- [x] Existing events tests pass

Fixes https://github.com/SciML/DifferentialEquations.jl/issues/1121

🤖 Generated with [Claude Code](https://claude.com/claude-code)