### PR TITLE
Fix forwarddiffs_model to return Bool instead of AD type

### DIFF
--- a/src/alg_utils.jl
+++ b/src/alg_utils.jl
@@ -36,7 +36,7 @@ function SciMLBase.forwarddiffs_model(
             StochasticDiffEqJumpNewtonDiffusionAdaptiveAlgorithm,
         }
     )
-    return OrdinaryDiffEqCore.alg_autodiff(alg)
+    return OrdinaryDiffEqCore.alg_autodiff(alg) isa ADTypes.AutoForwardDiff
 end
 
 # Required for initialization, because ODECore._initialize_dae! calls it during


### PR DESCRIPTION
## Summary

- `SciMLBase.forwarddiffs_model` for Newton-type SDE algorithms was returning the AD type directly (e.g. `AutoForwardDiff()`, `AutoFiniteDiff()`) instead of a `Bool`
- This is inconsistent with OrdinaryDiffEqCore's implementation which returns `alg_autodiff(alg) isa AutoForwardDiff` (a `Bool`)
- Fixes the return to use `isa ADTypes.AutoForwardDiff` check, matching the OrdinaryDiffEqCore pattern

## Context

This bug was discovered while working on DiffEqBase.jl PR #1281 (trait-gated `promote_f` to reduce method invalidations). The `_uses_forwarddiff` helper in DiffEqBase calls `SciMLBase.forwarddiffs_model(alg)` and expected a `Bool` return, but SDE algorithms were returning AD type objects, causing `MethodError` on Val dispatch.

## Test plan

- [x] Verified `forwarddiffs_model` returns `Bool` for all Newton-type SDE algorithms (SKenCarp, ImplicitEM, ImplicitEulerHeun, ImplicitRKMil, ISSEM, ISSEulerHeun)
- [x] Verified `autodiff=true` → `true`, `autodiff=false` → `false`
- [x] Verified explicit algorithms still default to `false`
- [x] Verified SDE solves work with both `autodiff=true` and `autodiff=false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)